### PR TITLE
Bugfix/ripple version api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ pids.txt
 py312/
 *.log*
 venv3/
+*huey.jsonld
+*flask.jsonld

--- a/production/step_2_create_stac.py
+++ b/production/step_2_create_stac.py
@@ -10,7 +10,7 @@ from ripple1d.ras_to_gpkg import new_stac_item_s3
 from ripple1d.ripple1d_logger import configure_logging
 
 
-def main(mip_group: str, processing_table_name: str, bucket: str, ripple1d_version: str):
+def main(mip_group: str, processing_table_name: str, bucket: str):
     """Read from database a list of geopackages to create stac items."""
     db = PGFim()
     optional_condition = "AND gpkg_complete=true AND stac_complete IS NULL"
@@ -61,6 +61,5 @@ if __name__ == "__main__":
     mip_group = "tx_ble_1"
     processing_table_name = "processing_tx_ble_1"
     bucket = "fim"
-    ripple1d_version = ripple1d.__version__
 
-    main(mip_group, processing_table_name, bucket, ripple1d_version)
+    main(mip_group, processing_table_name, bucket)

--- a/ripple1d/ops/fim_lib.py
+++ b/ripple1d/ops/fim_lib.py
@@ -217,6 +217,8 @@ def nwm_reach_model_stac(
             Key=key,
         )
         nwm_rm.update_write_ripple1d_parameters({"model_stac_item": f"https://{bucket}.s3.amazonaws.com/{key}"})
+    else:
+        nwm_rm.update_write_ripple1d_parameters({"model_stac_item": nwm_rm.model_stac_json_file})
 
 
 def update_stac_s3_location(stac_item_file: pystac.Item, bucket: str, s3_prefix: str):
@@ -300,7 +302,7 @@ def fim_lib_item(item_id: str, assets: list, stac_json: str, metadata: dict) -> 
     return item
 
 
-def fim_lib_stac(ras_project_directory: str, nwm_reach_id: str, s3_prefix: str, bucket: str):
+def fim_lib_stac(ras_project_directory: str, nwm_reach_id: str, s3_prefix: str = None, bucket: str = None):
     """Create a stac item for a fim library."""
     nwm_rm = NwmReachModel(ras_project_directory)
 

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -445,12 +445,7 @@ class RippleGeopackageSubsetter:
             json.dump(ripple1d_parameters, f, indent=4)
 
 
-def extract_submodel(
-    source_model_directory: str,
-    submodel_directory: str,
-    nwm_id: int,
-    ripple_version: str = ripple1d.__version__,
-):
+def extract_submodel(source_model_directory: str, submodel_directory: str, nwm_id: int):
     """Use ripple conflation data to create a new GPKG from an existing ras geopackage."""
     rsd = RippleSourceDirectory(source_model_directory)
     logging.info(f"Preparing to extract NWM ID {nwm_id} from {rsd.ras_project_file}")

--- a/ripple1d/ras_to_gpkg.py
+++ b/ripple1d/ras_to_gpkg.py
@@ -360,7 +360,8 @@ def new_stac_item(ras_project_directory: str, ras_s3_prefix: str):
     for asset_key in nwm_rm.assets:
 
         asset_info = get_asset_info(asset_key, nwm_rm)
-        asset_key = str(PurePosixPath(Path(asset_key.replace(nwm_rm.model_directory, ras_s3_prefix))))
+        if ras_s3_prefix:
+            asset_key = str(PurePosixPath(Path(asset_key.replace(nwm_rm.model_directory, ras_s3_prefix))))
         asset = pystac.Asset(
             os.path.relpath(asset_key),
             extra_fields=asset_info["extra_fields"],

--- a/ripple1d/utils/sqlite_utils.py
+++ b/ripple1d/utils/sqlite_utils.py
@@ -42,7 +42,7 @@ def insert_data(db_name: str, table_name: str, data: pd.DataFrame, boundary_cond
         c.execute(
             f"""
             INSERT OR REPLACE INTO {table_name} (reach_id, ds_depth, ds_wse, us_flow, us_depth, us_wse, boundary_condition)
-            VALUES ( ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES ( ?, ?, ?, ?, ?, ?, ?)
         """,
             (
                 int(row.reach_id),

--- a/ripple1d/utils/sqlite_utils.py
+++ b/ripple1d/utils/sqlite_utils.py
@@ -5,7 +5,6 @@ import sqlite3
 
 import pandas as pd
 
-import ripple1d
 from ripple1d.ras import RasManager
 
 
@@ -22,7 +21,6 @@ def create_db_and_table(db_name: str, table_name: str):
             us_flow INTEGER,
             us_depth REAL,
             us_wse REAL,
-            ripple1d_version TEXT,
             boundary_condition TEXT, -- [kwse, nd]
             UNIQUE(reach_id, us_flow, ds_wse, boundary_condition)
         )
@@ -35,13 +33,7 @@ def create_db_and_table(db_name: str, table_name: str):
     conn.close()
 
 
-def insert_data(
-    db_name: str,
-    table_name: str,
-    data: pd.DataFrame,
-    boundary_condition: str,
-    ripple1d_version: str = ripple1d.__version__,
-):
+def insert_data(db_name: str, table_name: str, data: pd.DataFrame, boundary_condition: str):
     """Insert data into the sqlite database."""
     conn = sqlite3.connect(db_name)
     c = conn.cursor()
@@ -49,7 +41,7 @@ def insert_data(
     for row in data.itertuples():
         c.execute(
             f"""
-            INSERT OR REPLACE INTO {table_name} (reach_id, ds_depth, ds_wse, us_flow, us_depth, us_wse, ripple1d_version, boundary_condition)
+            INSERT OR REPLACE INTO {table_name} (reach_id, ds_depth, ds_wse, us_flow, us_depth, us_wse, boundary_condition)
             VALUES ( ?, ?, ?, ?, ?, ?, ?, ?)
         """,
             (
@@ -59,7 +51,6 @@ def insert_data(
                 round(float(row.us_flow), 1),
                 round(float(row.us_depth), 1),
                 round(float(row.us_wse), 1),
-                str(ripple1d_version),
                 str(boundary_condition),
             ),
         )

--- a/tests/api_tests_Baxter.py
+++ b/tests/api_tests_Baxter.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import requests
 
-import ripple1d
 from ripple1d.ras import RasFlowText
 
 TEST_DIR = os.path.dirname(__file__)

--- a/tests/api_tests_Baxter.py
+++ b/tests/api_tests_Baxter.py
@@ -155,23 +155,14 @@ class TestApi(unittest.TestCase):
 
     @check_process
     def test_h_nwm_reach_model_stac(self):
-        payload = {
-            "ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
-            "ras_model_s3_prefix": f"stac/test-data/nwm_reach_models/{REACH_ID}",
-            "bucket": "fim",
-        }
+        payload = {"ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}"}
         process = "nwm_reach_model_stac"
         files = [MODEL_STAC_ITEM]
         return process, payload, files
 
     @check_process
     def test_i_fim_lib_stac(self):
-        payload = {
-            "ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
-            "nwm_reach_id": REACH_ID,
-            "s3_prefix": f"stac/test-data/fim_libs/{REACH_ID}",
-            "bucket": "fim",
-        }
+        payload = {"ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}", "nwm_reach_id": REACH_ID}
         process = "fim_lib_stac"
         files = [FIM_LIB_STAC_ITEM]
         return process, payload, files

--- a/tests/api_tests_Baxter.py
+++ b/tests/api_tests_Baxter.py
@@ -90,7 +90,6 @@ class TestApi(unittest.TestCase):
             "source_model_directory": SOURCE_RAS_MODEL_DIRECTORY,
             "submodel_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
             "nwm_id": REACH_ID,
-            "ripple_version": ripple1d.__version__,
         }
         process = "extract_submodel"
         files = [GPKG_FILE]

--- a/tests/api_tests_MissFldwy.py
+++ b/tests/api_tests_MissFldwy.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import requests
 
-import ripple1d
 from ripple1d.ras import RasFlowText
 
 TEST_DIR = os.path.dirname(__file__)

--- a/tests/api_tests_MissFldwy.py
+++ b/tests/api_tests_MissFldwy.py
@@ -155,23 +155,14 @@ class TestApi(unittest.TestCase):
 
     @check_process
     def test_h_nwm_reach_model_stac(self):
-        payload = {
-            "ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
-            "ras_model_s3_prefix": f"stac/test-data/nwm_reach_models/{REACH_ID}",
-            "bucket": "fim",
-        }
+        payload = {"ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}"}
         process = "nwm_reach_model_stac"
         files = [MODEL_STAC_ITEM]
         return process, payload, files
 
     @check_process
     def test_i_fim_lib_stac(self):
-        payload = {
-            "ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
-            "nwm_reach_id": REACH_ID,
-            "s3_prefix": f"stac/test-data/fim_libs/{REACH_ID}",
-            "bucket": "fim",
-        }
+        payload = {"ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}", "nwm_reach_id": REACH_ID}
         process = "fim_lib_stac"
         files = [FIM_LIB_STAC_ITEM]
         return process, payload, files

--- a/tests/api_tests_MissFldwy.py
+++ b/tests/api_tests_MissFldwy.py
@@ -90,7 +90,6 @@ class TestApi(unittest.TestCase):
             "source_model_directory": SOURCE_RAS_MODEL_DIRECTORY,
             "submodel_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
             "nwm_id": REACH_ID,
-            "ripple_version": ripple1d.__version__,
         }
         process = "extract_submodel"
         files = [GPKG_FILE]

--- a/tests/api_tests_PatuxentRiver.py
+++ b/tests/api_tests_PatuxentRiver.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import requests
 
-import ripple1d
 from ripple1d.ras import RasFlowText
 
 TEST_DIR = os.path.dirname(__file__)

--- a/tests/api_tests_PatuxentRiver.py
+++ b/tests/api_tests_PatuxentRiver.py
@@ -155,11 +155,7 @@ class TestApi(unittest.TestCase):
 
     @check_process
     def test_h_nwm_reach_model_stac(self):
-        payload = {
-            "ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
-            "ras_model_s3_prefix": f"stac/test-data/nwm_reach_models/{REACH_ID}",
-            "bucket": "fim",
-        }
+        payload = {"ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}"}
         process = "nwm_reach_model_stac"
         files = [MODEL_STAC_ITEM]
         return process, payload, files
@@ -169,8 +165,6 @@ class TestApi(unittest.TestCase):
         payload = {
             "ras_project_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
             "nwm_reach_id": REACH_ID,
-            "s3_prefix": f"stac/test-data/fim_libs/{REACH_ID}",
-            "bucket": "fim",
         }
         process = "fim_lib_stac"
         files = [FIM_LIB_STAC_ITEM]

--- a/tests/api_tests_PatuxentRiver.py
+++ b/tests/api_tests_PatuxentRiver.py
@@ -90,7 +90,6 @@ class TestApi(unittest.TestCase):
             "source_model_directory": SOURCE_RAS_MODEL_DIRECTORY,
             "submodel_directory": f"{SUBMODELS_BASE_DIRECTORY}\\{REACH_ID}",
             "nwm_id": REACH_ID,
-            "ripple_version": ripple1d.__version__,
         }
         process = "extract_submodel"
         files = [GPKG_FILE]


### PR DESCRIPTION
This pull requests removes ripple_version as an optional arg from all api processes. If you try to submit ripple_version as part of the payload you should get  "unexpected args: ['ripple_version']". It also removes ripple1d_version from the rating curve DB. Lastly it adds flask and huey logs to the gitignore. 
  
  Fixes #131