### PR TITLE
bugfix for models with no structures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ripple1d"
-version = "0.4.1"
+version = "0.4.2"
 description = "HEC-RAS model automation"
 readme = "README.md"
 maintainers = [

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -246,6 +246,8 @@ class RippleGeopackageSubsetter:
                 & (self.source_structure["river_station"] >= float(self.ds_rs))
                 & (self.source_structure["river_station"] <= float(self.us_rs))
             ]
+        else:
+            structures_subset_gdf = None
         river_subset_gdf = self.source_river.loc[
             (self.source_river["river"] == self.us_river) & (self.source_river["reach"] == self.us_reach)
         ]

--- a/ripple1d/version.py
+++ b/ripple1d/version.py
@@ -1,3 +1,3 @@
 """ripple1d version."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"


### PR DESCRIPTION
This PR fixes a bug which caused a failure when calling `subset_gpkg` in cases where  the model geometries are simple (no structures / no junctions). This was not caught with test models because test models all have structures.