### PR TITLE
Bugfix/conflation tests

### DIFF
--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -345,10 +345,10 @@ class RasFimConflater:
     def ras_xs_convex_hull(self, river_reach_name: str = None):
         """Return the convex hull of the cross sections."""
         if river_reach_name:
-            polygon = self.ras_xs["geometry"].unary_union.convex_hull
+            polygon = self.ras_xs["geometry"].union_all().convex_hull
 
         else:
-            polygon = self.ras_xs["geometry"].unary_union.convex_hull
+            polygon = self.ras_xs["geometry"].union_all().convex_hull
 
         return gpd.GeoDataFrame({"geometry": [polygon]}, geometry="geometry", crs=self.ras_xs.crs)
 

--- a/tests/conflation_tests.py
+++ b/tests/conflation_tests.py
@@ -16,7 +16,7 @@ from ripple1d.conflate.rasfim import (
     filter_gdf,
     nearest_line_to_point,
 )
-from ripple1d.ops.ras_conflate import conflate
+from ripple1d.ops.ras_conflate import conflate_model
 
 TEST_DIR = os.path.dirname(__file__)
 TEST_ITEM_FILE = "ras-data/Baxter.json"


### PR DESCRIPTION
This is a bugfix that updates "conflate" to "conflate_model" when importing in conflation_tests.py. "unary_union" was also updated to "union_all()" to prevent warning message. 