### PR TITLE
Feature/delete raw ras grids

### DIFF
--- a/ripple1d/api/postman_collection.json
+++ b/ripple1d/api/postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a4de6034-22c7-4a2b-b91c-12494de19040",
+		"_postman_id": "c9f7dbb7-0b52-42d6-ba15-209b33e020dc",
 		"name": "ripple1d",
 		"description": "Collection for processing existing HEC-RAS models for use in the production of Flood Inundation Maps (FIMs) and rating curves for use in near-real time flood forecasting on the NOAA National Water Model",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -307,7 +307,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"submodel_directory\": \"{{submodels_base_directory}}\\\\{{nwm_reach_id}}\",\r\n    \"plans\": [\"nd\",\"kwse\"],\r\n    \"resolution\":3,\r\n    \"resolution_units\":\"Meters\"\r\n}",
+							"raw": "{\r\n    \"submodel_directory\": \"{{submodels_base_directory}}\\\\{{nwm_reach_id}}\",\r\n    \"plans\": [\"nd\",\"kwse\"],\r\n    \"cleanup\":true,\r\n    \"resolution\":3,\r\n    \"resolution_units\":\"Meters\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/ripple1d/ops/fim_lib.py
+++ b/ripple1d/ops/fim_lib.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import shutil
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 
@@ -127,10 +128,11 @@ def post_process_depth_grids(
 def create_fim_lib(
     submodel_directory: str,
     plans: list,
+    cleanup: bool,
     ras_version: str = "631",
     table_name: str = "rating_curves",
-    tiled=False,
-    overviews=False,
+    tiled: bool = False,
+    overviews: bool = False,
     resolution: float = 3,
     resolution_units: str = "Meters",
 ):
@@ -168,6 +170,8 @@ def create_fim_lib(
                 nwm_rm.fim_results_database,
                 table_name,
             )
+            if cleanup:
+                shutil.rmtree(os.path.join(rm.ras_project._ras_dir, f"{nwm_rm.model_name}_kwse"))
         if f"nd" in plan:
             zero_depth_to_sqlite(
                 rm,
@@ -177,6 +181,8 @@ def create_fim_lib(
                 nwm_rm.fim_results_database,
                 table_name,
             )
+            if cleanup:
+                shutil.rmtree(os.path.join(rm.ras_project._ras_dir, f"{nwm_rm.model_name}_nd"))
 
     return {"fim_results_directory": nwm_rm.fim_results_directory, "fim_results_database": nwm_rm.fim_results_database}
 

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -161,7 +161,7 @@ class TestApi(unittest.TestCase):
 
     @check_process
     def test_g_create_fim_lib(self):
-        payload = {"submodel_directory": self.SUBMODELS_DIRECTORY, "plans": ["nd", "kwse"]}
+        payload = {"submodel_directory": self.SUBMODELS_DIRECTORY, "plans": ["nd", "kwse"], "cleanup": True}
         process = "create_fim_lib"
         files = [self.FIM_LIB_DB, self.DEPTH_GRIDS_ND, self.DEPTH_GRIDS_KWSE]
         return process, payload, files


### PR DESCRIPTION
This PR adds a new required arg (cleanup) to the create_fim_lib endpoint. If this arg is True the raw HEC-RAS depth grids are deleted. If False they are left. 

Closes#151