### PR TITLE
Bugfix/depth grids

### DIFF
--- a/ripple1d/ops/fim_lib.py
+++ b/ripple1d/ops/fim_lib.py
@@ -1,5 +1,6 @@
 """Create FIM library."""
 
+import glob
 import json
 import logging
 import os
@@ -56,8 +57,8 @@ def post_process_depth_grids(
         for profile_name in rm.plans[plan_name].flow.profile_names:
             # construct the default path to the depth grid for this plan/profile
             src_dir = os.path.join(rm.ras_project._ras_dir, str(plan_name))
-            terrain_part = os.path.basename(os.listdir(src_dir)[0]).split(".")[-2]
-
+            terrain_dir = os.path.join(rm.ras_project._ras_dir, "Terrain")
+            terrain_part = os.path.basename(glob.glob(terrain_dir + "\\*.tif")[0]).split(".")[-2]
             src_path = os.path.join(
                 src_dir,
                 f"Depth ({profile_name}).{rm.ras_project.title}.{terrain_part}.tif",


### PR DESCRIPTION
This error is arising because all normal depth runs are below the mapping terrain which means no resulting depth grids.
![image](https://github.com/user-attachments/assets/ff8ee01d-0f45-46f9-a380-0828ae521836)

Previously the code assumed at least 1 depth grid would be present. This has been fixed by obtaining the "terrain part" of the raw RAS grid from the RAS terrain instead of the first depth grid in the raw RAS result folder. 

Closes #170