### PR TITLE
check if reach is eclipsed

### DIFF
--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -479,7 +479,7 @@ def extract_submodel(source_model_directory: str, submodel_directory: str, nwm_i
         raise FileNotFoundError(f"cannot find conflation file {rsd.conflation_file}, please ensure file exists")
 
     ripple1d_parameters = rsd.nwm_conflation_parameters(str(nwm_id))
-    if ripple1d_parameters["us_xs"]["xs_id"] == "-9999":
+    if ripple1d_parameters["eclipsed"]:
         ripple1d_parameters["messages"] = f"skipping {nwm_id}; no cross sections conflated."
         logging.warning(ripple1d_parameters["messages"])
 


### PR DESCRIPTION
The extract submodel endpoint was not checking for eclipsed reaches and was failing when trying to grab the upstream cross section. This bugfix checks if the eclipsed parameter is set to True. If it is then a extract submodel will not create a geopackage. 

Closes #190