### PR TITLE
Bugfix/fim lib

### DIFF
--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -198,8 +198,9 @@ class RippleSourceDirectory:
 class NwmReachModel(RasModelStructure):
     """National Water Model reach-based HEC-RAS Model files and directory structure."""
 
-    def __init__(self, model_directory: str):
+    def __init__(self, model_directory: str, library_directory: str = ""):
         super().__init__(model_directory)
+        self.library_directory = library_directory
 
     @property
     def terrain_directory(self):
@@ -214,7 +215,7 @@ class NwmReachModel(RasModelStructure):
     @property
     def fim_results_directory(self):
         """FIM results directory."""
-        return str(Path(self.model_directory) / "fims")
+        return str(Path(self.library_directory) / self.model_name)
 
     @property
     def fim_lib_assets(self):

--- a/ripple1d/ops/fim_lib.py
+++ b/ripple1d/ops/fim_lib.py
@@ -139,13 +139,14 @@ def create_fim_lib(
     resolution_units: str = "Meters",
 ):
     """Create a new FIM library for a NWM id."""
-    nwm_rm = NwmReachModel(submodel_directory)
-    if not nwm_rm.file_exists(nwm_rm.ras_gpkg_file):
-        raise FileNotFoundError(f"cannot find ras_gpkg_file file {nwm_rm.ras_gpkg_file}, please ensure file exists")
+    nwm_rm = NwmReachModel(submodel_directory, library_directory)
 
-    crs = gpd.read_file(nwm_rm.ras_gpkg_file, layer="XS").crs
-
-    rm = RasManager(nwm_rm.ras_project_file, version=ras_version, terrain_path=nwm_rm.ras_terrain_hdf, crs=crs)
+    rm = RasManager(
+        nwm_rm.ras_project_file,
+        version=ras_version,
+        terrain_path=nwm_rm.ras_terrain_hdf,
+        crs=nwm_rm.crs,
+    )
     ras_plans = [f"{nwm_rm.model_name}_{plan}" for plan in plans]
 
     missing_grids_kwse, missing_grids_nd = post_process_depth_grids(

--- a/ripple1d/ops/fim_lib.py
+++ b/ripple1d/ops/fim_lib.py
@@ -161,7 +161,8 @@ def create_fim_lib(
     )
 
     # create dabase and table
-    create_db_and_table(nwm_rm.fim_results_database, table_name)
+    if not os.path.exists(nwm_rm.fim_results_database):
+        create_db_and_table(nwm_rm.fim_results_database, table_name)
 
     for plan in plans:
         if f"kwse" in plan:

--- a/ripple1d/ops/fim_lib.py
+++ b/ripple1d/ops/fim_lib.py
@@ -174,7 +174,7 @@ def create_fim_lib(
                 table_name,
             )
             if cleanup:
-                shutil.rmtree(os.path.join(rm.ras_project._ras_dir, f"{nwm_rm.model_name}_kwse"))
+                shutil.rmtree(os.path.join(rm.ras_project._ras_dir, f"{nwm_rm.model_name}_kwse"), ignore_errors=True)
         if f"nd" in plan:
             zero_depth_to_sqlite(
                 rm,
@@ -185,7 +185,7 @@ def create_fim_lib(
                 table_name,
             )
             if cleanup:
-                shutil.rmtree(os.path.join(rm.ras_project._ras_dir, f"{nwm_rm.model_name}_nd"))
+                shutil.rmtree(os.path.join(rm.ras_project._ras_dir, f"{nwm_rm.model_name}_nd"), ignore_errors=True)
 
     return {"fim_results_directory": nwm_rm.fim_results_directory, "fim_results_database": nwm_rm.fim_results_database}
 

--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -31,7 +31,7 @@ def create_model_run_normal_depth(
     if not nwm_rm.file_exists(nwm_rm.ras_gpkg_file):
         raise FileNotFoundError(f"cannot find ras_gpkg_file file {nwm_rm.ras_gpkg_file}, please ensure file exists")
 
-    if nwm_rm.ripple1d_parameters["us_xs"]["xs_id"] == "-9999":
+    if nwm_rm.ripple1d_parameters["eclipsed"] == True:
         logging.warning(f"skipping {nwm_rm.model_name}; no cross sections conflated.")
     else:
         logging.info(f"Working on initial normal depth run for nwm_id: {nwm_rm.model_name}")
@@ -80,18 +80,15 @@ def run_incremental_normal_depth(
     if not nwm_rm.file_exists(nwm_rm.conflation_file):
         raise FileNotFoundError(f"cannot find conflation file {nwm_rm.conflation_file}, please ensure file exists")
 
-    if not nwm_rm.file_exists(nwm_rm.ras_gpkg_file):
-        raise FileNotFoundError(f"cannot find ras_gpkg_file file {nwm_rm.ras_gpkg_file}, please ensure file exists")
-
     logging.info(f"Working on normal depth run for nwm_id: {nwm_rm.model_name}")
-    if nwm_rm.ripple1d_parameters["us_xs"]["xs_id"] == "-9999":
+    if nwm_rm.ripple1d_parameters["eclipsed"] == True:
         logging.warning(f"skipping {nwm_rm.model_name}; no cross sections conflated.")
 
     rm = RasManager(
         nwm_rm.ras_project_file,
         version=ras_version,
         terrain_path=nwm_rm.ras_terrain_hdf,
-        crs=nwm_rm.ripple1d_parameters["crs"],
+        crs=nwm_rm.crs,
     )
 
     # determine flow increments
@@ -139,18 +136,13 @@ def run_known_wse(
     if not nwm_rm.file_exists(nwm_rm.conflation_file):
         raise FileNotFoundError(f"cannot find conflation file {nwm_rm.conflation_file}, please ensure file exists")
 
-    if not nwm_rm.file_exists(nwm_rm.ras_gpkg_file):
-        raise FileNotFoundError(f"cannot find ras_gpkg_file file {nwm_rm.ras_gpkg_file}, please ensure file exists")
-
     logging.info(f"Working on known water surface elevation run for nwm_id: {nwm_rm.model_name}")
 
     start_elevation = np.floor(min_elevation * 2) / 2  # round down to nearest .0 or .5
     known_water_surface_elevations = np.arange(start_elevation, max_elevation + depth_increment, depth_increment)
 
-    crs = gpd.read_file(nwm_rm.ras_gpkg_file, layer="XS").crs
-
     # write and compute flow/plans for known water surface elevation runs
-    rm = RasManager(nwm_rm.ras_project_file, version=ras_version, terrain_path=nwm_rm.ras_terrain_hdf, crs=crs)
+    rm = RasManager(nwm_rm.ras_project_file, version=ras_version, terrain_path=nwm_rm.ras_terrain_hdf, crs=nwm_rm.crs)
 
     # get resulting depths from the second normal depth runs_nd
     rm.plan = rm.plans[f"{nwm_rm.model_name}_nd"]

--- a/ripple1d/utils/sqlite_utils.py
+++ b/ripple1d/utils/sqlite_utils.py
@@ -10,9 +10,6 @@ from ripple1d.ras import RasManager
 
 def create_db_and_table(db_name: str, table_name: str):
     """Create sqlite database and table."""
-    if os.path.exists(db_name):
-        os.remove(db_name)
-
     sql_query = f"""
         CREATE TABLE {table_name}(
             reach_id INTEGER,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def setup_data(request):
     SOURCE_RAS_MODEL_DIRECTORY = os.path.join(TEST_DIR, f"ras-data\\{RAS_MODEL}")
     SUBMODELS_BASE_DIRECTORY = os.path.join(SOURCE_RAS_MODEL_DIRECTORY, "submodels")
     SUBMODELS_DIRECTORY = os.path.join(SUBMODELS_BASE_DIRECTORY, REACH_ID)
+    FIM_LIB_DIRECTORY = os.path.join(SUBMODELS_DIRECTORY, "fim")
     request.cls.REACH_ID = RAS_MODEL
     request.cls.REACH_ID = REACH_ID
 
@@ -33,6 +34,7 @@ def setup_data(request):
     request.cls.SOURCE_RAS_MODEL_DIRECTORY = SOURCE_RAS_MODEL_DIRECTORY
     request.cls.SUBMODELS_BASE_DIRECTORY = SUBMODELS_BASE_DIRECTORY
     request.cls.SUBMODELS_DIRECTORY = SUBMODELS_DIRECTORY
+    request.cls.FIM_LIB_DIRECTORY = FIM_LIB_DIRECTORY
     request.cls.GPKG_FILE = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.gpkg")
     request.cls.SOURCE_GPKG_FILE = os.path.join(SOURCE_RAS_MODEL_DIRECTORY, f"{RAS_MODEL}.gpkg")
     request.cls.TERRAIN_HDF = os.path.join(SUBMODELS_DIRECTORY, f"Terrain\\{REACH_ID}.hdf")
@@ -48,10 +50,10 @@ def setup_data(request):
     request.cls.PLAN3_FILE = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.p03")
     request.cls.FLOW3_FILE = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.f03")
     request.cls.RESULT3_FILE = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.r03")
-    request.cls.FIM_LIB_DB = os.path.join(SUBMODELS_DIRECTORY, f"fims\\{REACH_ID}.db")
-    request.cls.DEPTH_GRIDS_ND = os.path.join(SUBMODELS_DIRECTORY, f"fims\\z_nd")
+    request.cls.FIM_LIB_DB = os.path.join(FIM_LIB_DIRECTORY, f"{REACH_ID}\\{REACH_ID}.db")
+    request.cls.DEPTH_GRIDS_ND = os.path.join(FIM_LIB_DIRECTORY, f"{REACH_ID}\\z_nd")
     integer, decimal = str(np.floor((MIN_ELEVATION + 41) * 2) / 2).split(".")
-    request.cls.DEPTH_GRIDS_KWSE = os.path.join(SUBMODELS_DIRECTORY, f"fims\\z_{integer}_{decimal}")
+    request.cls.DEPTH_GRIDS_KWSE = os.path.join(FIM_LIB_DIRECTORY, f"{REACH_ID}\\z_{integer}_{decimal}")
     request.cls.MODEL_STAC_ITEM = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.model.stac.json")
     request.cls.FIM_LIB_STAC_ITEM = os.path.join(SUBMODELS_DIRECTORY, f"fims\\{REACH_ID}.fim_lib.stac.json")
     request.cls.min_elevation = MIN_ELEVATION


### PR DESCRIPTION
This PR fixes 3 bugs associated with the create_fim_lib endpoint. 

1. The library_directory arg was not being implemented correctly in the function. 
2. The behavior of appending to a fim.db if it already exists has been implemented.
3.  Lastly, if the directory containing the raw RAS depth grids was empty the clean up function was producing an error. This has been addressed so no error is produced. 

Closes #193