### PR TITLE
Bugfix/reversed xs

### DIFF
--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -13,11 +13,11 @@ import numpy as np
 import pandas as pd
 import pyproj
 from fiona.errors import DriverError
-from shapely.geometry import LineString, MultiLineString, MultiPoint, Point, Polygon, box
+from shapely import LineString, MultiLineString, MultiPoint, Point, Polygon, box, reverse
 from shapely.ops import linemerge, nearest_points, transform
 
 from ripple1d.consts import METERS_PER_FOOT
-from ripple1d.utils.ripple_utils import xs_concave_hull
+from ripple1d.utils.ripple_utils import check_xs_direction, fix_reversed_xs, validate_point, xs_concave_hull
 
 HIGH_FLOW_FACTOR = 1.2
 
@@ -74,7 +74,7 @@ class RasFimConflater:
         self.nwm_pq = nwm_pq
         self.source_model_directory = source_model_directory
         self.ras_model_name = os.path.basename(source_model_directory)
-        self.ras_gpkg = os.path.join(source_model_directory,f"{self.ras_model_name}.gpkg")
+        self.ras_gpkg = os.path.join(source_model_directory, f"{self.ras_model_name}.gpkg")
 
         self.output_concave_hull_path = output_concave_hull_path
         self._nwm_reaches = None
@@ -83,7 +83,7 @@ class RasFimConflater:
         self._ras_xs = None
         self._ras_structures = None
         self._ras_junctions = None
-        self._ras_metadata=None
+        self._ras_metadata = None
         self._common_crs = None
         self._xs_hulls = None
         self.__data_loaded = False
@@ -91,12 +91,10 @@ class RasFimConflater:
             self._common_crs = NWM_CRS
             self.load_data()
             self.__data_loaded = True
-            
 
     def __repr__(self):
         """Return the string representation of the object."""
         return f"RasFimConflater(nwm_pq={self.nwm_pq}, ras_gpkg={self.ras_gpkg})"
-
 
     @property
     def stac_api(self):
@@ -104,15 +102,14 @@ class RasFimConflater:
         if self.ras_metadata:
             if "stac_api" in self.ras_metadata.keys():
                 return self.ras_metadata["stac_api"]
-    
+
     @property
     def stac_collection_id(self):
         """The stac_collection_id for the HEC-RAS Model."""
         if self.ras_metadata:
             if "stac_collection_id" in self.ras_metadata.keys():
                 return self.ras_metadata["stac_collection_id"]
-        
-    
+
     @property
     def stac_item_id(self):
         """The stac_item_id for the HEC-RAS Model."""
@@ -131,7 +128,7 @@ class RasFimConflater:
         """The primary flow file for the HEC-RAS Model."""
         if self.ras_metadata:
             return self.ras_metadata["primary_flow_file"]
-    
+
     @property
     def primary_plan_file(self):
         """The primary plan file for the HEC-RAS Model."""
@@ -142,7 +139,7 @@ class RasFimConflater:
     def ras_project_file(self):
         """The source HEC-RAS project file."""
         if self.ras_metadata:
-            return self.ras_metadata["ras_project_file"] 
+            return self.ras_metadata["ras_project_file"]
 
     # @property
     # def xs_length_units(self):
@@ -186,8 +183,7 @@ class RasFimConflater:
     #             return "miles"
     #         else:
     #             raise ValueError(f"Unable to determine reach length units from reach length r values")
-            
-        
+
     # @property
     # def flow_units(self):
     #     """Flow units of the source HEC-RAS model."""
@@ -198,11 +194,11 @@ class RasFimConflater:
     #     elif self.ras_metadata["units"] == "English":
     #         return "cfs"
 
-    def populate_r_station(self, row: pd.Series,assume_ft:bool=True) -> str:
+    def populate_r_station(self, row: pd.Series, assume_ft: bool = True) -> str:
         """Populate the r value for a cross section. The r value is the ratio of the station to actual cross section length."""
-        #TODO check if this is the correct way to calculate r
+        # TODO check if this is the correct way to calculate r
         df = pd.DataFrame(row["station_elevation_points"], index=["elevation"]).T
-        return df.index.max()/(row.geometry.length/METERS_PER_FOOT)
+        return df.index.max() / (row.geometry.length / METERS_PER_FOOT)
 
     @property
     def _gpkg_metadata(self):
@@ -212,24 +208,24 @@ class RasFimConflater:
             cur.execute("select * from metadata")
             return dict(cur.fetchall())
 
-    def determine_station_order(self, xs_gdf: gpd.GeoDataFrame,reach:LineString):
+    def determine_station_order(self, xs_gdf: gpd.GeoDataFrame, reach: LineString):
         """Detemine the order based on stationing of the cross sections along the reach."""
-        rs=[]
+        rs = []
         for _, xs in xs_gdf.iterrows():
-            geom=reach.intersection(xs.geometry)
+            geom = reach.intersection(xs.geometry)
             try:
-                point=validate_point(geom)
+                point = validate_point(geom)
                 rs.append(reach.project(point))
             except TypeError as e:
                 rs.append(rs[-1])
-            
-        xs_gdf["rs"]=rs
-        return xs_gdf.sort_values(by="rs",ignore_index=True)
 
-    def add_hull(self, xs_gdf: gpd.GeoDataFrame,reach:LineString):
+        xs_gdf["rs"] = rs
+        return xs_gdf.sort_values(by="rs", ignore_index=True)
+
+    def add_hull(self, xs_gdf: gpd.GeoDataFrame, reach: LineString):
         """Add the concave hull to the GeoDataFrame."""
         if len(xs_gdf) > 1:
-            xs_gdf=self.determine_station_order(xs_gdf,reach)
+            xs_gdf = self.determine_station_order(xs_gdf, reach)
             hull = xs_concave_hull(xs_gdf)
             if self._xs_hulls is None:
                 self._xs_hulls = hull
@@ -253,20 +249,20 @@ class RasFimConflater:
         if "River" in layers:
             self._ras_centerlines = gpd.read_file(self.ras_gpkg, layer="River")
         if "XS" in layers:
-            xs=gpd.read_file(self.ras_gpkg, layer="XS")
+            xs = gpd.read_file(self.ras_gpkg, layer="XS")
             self._ras_xs = xs[xs.intersects(self._ras_centerlines.union_all())]
         if "Junction" in layers:
             self._ras_junctions = gpd.read_file(self.ras_gpkg, layer="Junction")
         if "Structure" in layers:
-            structures=gpd.read_file(self.ras_gpkg, layer="Structure")
+            structures = gpd.read_file(self.ras_gpkg, layer="Structure")
             self._ras_structures = structures[structures.intersects(self._ras_centerlines.union_all())]
         if "metadata" in layers:
-            self._ras_metadata=self._gpkg_metadata
+            self._ras_metadata = self._gpkg_metadata
 
     def load_pq(self, nwm_pq: str):
         """Load the NWM data from the Parquet file."""
         try:
-            nwm_reaches = gpd.read_parquet(nwm_pq,bbox=self._ras_xs.to_crs(self.common_crs).total_bounds)
+            nwm_reaches = gpd.read_parquet(nwm_pq, bbox=self._ras_xs.to_crs(self.common_crs).total_bounds)
             nwm_reaches = nwm_reaches.rename(columns={"geom": "geometry"})
             self._nwm_reaches = nwm_reaches.set_geometry("geometry")
         except Exception as e:
@@ -322,7 +318,7 @@ class RasFimConflater:
             return self._ras_structures.to_crs(self.common_crs)
         except AttributeError:
             return None
-        
+
     @property
     @ensure_data_loaded
     def ras_junctions(self) -> gpd.GeoDataFrame:
@@ -434,13 +430,15 @@ class RasFimConflater:
         return wrapper
 
     @check_centerline
-    def ras_start_end_points(self, river_reach_name: str = None, centerline=None,clip_to_xs=False) -> Tuple[Point, Point]:
+    def ras_start_end_points(
+        self, river_reach_name: str = None, centerline=None, clip_to_xs=False
+    ) -> Tuple[Point, Point]:
         """River_reach_name used by the decorator to get the centerline."""
         if river_reach_name:
-            centerline = self.ras_centerline_by_river_reach_name(river_reach_name,clip_to_xs)
+            centerline = self.ras_centerline_by_river_reach_name(river_reach_name, clip_to_xs)
         return endpoints_from_multiline(centerline)
 
-    def ras_centerline_by_river_reach_name(self, river_reach_name: str,clip_to_xs=False) -> LineString:
+    def ras_centerline_by_river_reach_name(self, river_reach_name: str, clip_to_xs=False) -> LineString:
         """Return the centerline for the specified river reach."""
         if clip_to_xs:
             return (
@@ -749,16 +747,12 @@ def map_reach_xs(rfc: RasFimConflater, reach: MultiLineString) -> dict:
     # add xs concave hull
     if rfc.output_concave_hull_path:
         xs_gdf = pd.concat([intersected_xs, rfc.ras_xs[rfc.ras_xs["ID"] == ds_xs]], ignore_index=True)
-        rfc.add_hull(xs_gdf,reach.geometry)
-    
-    if us_data==ds_data:
-        return {"eclipsed":True}
+        rfc.add_hull(xs_gdf, reach.geometry)
 
-    return {
-        "us_xs": us_data,
-        "ds_xs": ds_data,
-        "eclipsed":False
-    }
+    if us_data == ds_data:
+        return {"eclipsed": True}
+
+    return {"us_xs": us_data, "ds_xs": ds_data, "eclipsed": False}
 
 
 def ras_reaches_metadata(rfc: RasFimConflater, candidate_reaches: gpd.GeoDataFrame):

--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -16,10 +16,12 @@ from shapely.geometry import LineString, Point
 
 from ripple1d.utils.ripple_utils import (
     data_pairs_from_text_block,
+    fix_reversed_xs,
     search_contents,
     text_block_from_start_end_str,
     text_block_from_start_str_length,
     text_block_from_start_str_to_empty_line,
+    xs_concave_hull,
 )
 from ripple1d.utils.s3_utils import init_s3_resources, read_json_from_s3
 
@@ -55,6 +57,14 @@ class RasModelStructure:
     def ras_gpkg_file(self):
         """RAS GeoPackage file."""
         return self.derive_path(".gpkg")
+
+
+    @property
+    def xs_concave_hull(self):
+        """XS Concave Hull."""
+        if self._xs_concave_hull is None:
+            self._xs_concave_hull = xs_concave_hull(fix_reversed_xs(self.ras_xs, self.ras_rivers))
+        return self._xs_concave_hull
 
     @property
     def assets(self):

--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -32,6 +32,11 @@ class RasModelStructure:
     def __init__(self, model_directory: str):
         self.model_directory = model_directory
         self.model_basename = Path(model_directory).name
+        self._ras_junctions = None
+        self._ras_structures = None
+        self._ras_xs = None
+        self._ras_rivers = None
+        self._xs_concave_hull = None
 
     @property
     def model_name(self):
@@ -58,6 +63,35 @@ class RasModelStructure:
         """RAS GeoPackage file."""
         return self.derive_path(".gpkg")
 
+    @property
+    def ras_xs(self):
+        """RAS XS Geodataframe."""
+        if self._ras_xs is None:
+            self._ras_xs = gpd.read_file(self.ras_gpkg_file, layer="XS")
+        return self._ras_xs
+
+    @property
+    def ras_junctions(self):
+        """RAS Junctions Geodataframe."""
+        if "Junction" in fiona.listlayers(self.ras_gpkg_file):
+            if self._ras_junctions is None:
+                self._ras_junctions = gpd.read_file(self.ras_gpkg_file, layer="Junction")
+            return self._ras_junctions
+
+    @property
+    def ras_structures(self):
+        """RAS Structures Geodataframe."""
+        if "Structure" in fiona.listlayers(self.ras_gpkg_file):
+            if self._ras_structures is None:
+                self._ras_structures = gpd.read_file(self.ras_gpkg_file, layer="Structure")
+            return self._ras_structures
+
+    @property
+    def ras_rivers(self):
+        """RAS Rivers Geodataframe."""
+        if self._ras_rivers is None:
+            self._ras_rivers = gpd.read_file(self.ras_gpkg_file, layer="River")
+        return self._ras_rivers
 
     @property
     def xs_concave_hull(self):

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -24,6 +24,11 @@ class RippleGeopackageSubsetter:
         self.conflation_json = conflation_json
         self.dst_project_dir = dst_project_dir
         self.nwm_id = nwm_id
+        self._subset_gdf = None
+        self._source_junction = None
+        self._source_river = None
+        self._source_xs = None
+        self._source_structure = None
 
     @property
     def conflation_parameters(self) -> dict:
@@ -69,27 +74,34 @@ class RippleGeopackageSubsetter:
     @property
     def source_xs(self) -> gpd.GeoDataFrame:
         """Extract cross sections from the source geopackage."""
-        xs = gpd.read_file(self.src_gpkg_path, layer="XS")
-        return xs[xs.intersects(self.source_river.union_all())]
+        if self._source_xs is None:
+            xs = gpd.read_file(self.src_gpkg_path, layer="XS")
+            self._source_xs = xs[xs.intersects(self.source_river.union_all())]
+        return self._source_xs
 
     @property
     def source_river(self) -> gpd.GeoDataFrame:
         """Extract river geometry from the source geopackage."""
-        return gpd.read_file(self.src_gpkg_path, layer="River")
+        if self._source_river is None:
+            self._source_river = gpd.read_file(self.src_gpkg_path, layer="River")
+        return self._source_river
 
     @property
     def source_structure(self) -> gpd.GeoDataFrame:
         """Extract structures from the source geopackage."""
         if "Structure" in fiona.listlayers(self.src_gpkg_path):
-            structures = gpd.read_file(self.src_gpkg_path, layer="Structure")
-            return structures[structures.intersects(self.source_river.union_all())]
+            if self._source_structure is None:
+                structures = gpd.read_file(self.src_gpkg_path, layer="Structure")
+                self._source_structure = structures[structures.intersects(self.source_river.union_all())]
+            return self._source_structure
 
     @property
     def source_junction(self) -> gpd.GeoDataFrame:
         """Extract junctions from the source geopackage."""
         if "Junction" in fiona.listlayers(self.src_gpkg_path):
-            return gpd.read_file(self.src_gpkg_path, layer="Junction")
-        return None
+            if self._source_junction is None:
+                self._source_junction = gpd.read_file(self.src_gpkg_path, layer="Junction")
+            return self._source_junction
 
     @property
     def ripple_xs(self) -> gpd.GeoDataFrame:
@@ -109,29 +121,32 @@ class RippleGeopackageSubsetter:
     @property
     def subset_gdfs(self) -> dict:
         """Subset the cross sections, structues, and river geometry for a given NWM reach."""
-        # subset data
-        if self.us_river == self.ds_river and self.us_reach == self.ds_reach:
-            ripple_xs, ripple_structure, ripple_river = self.process_as_one_ras_reach()
-        else:
-            ripple_xs, ripple_structure, ripple_river = self.process_as_multiple_ras_reach()
+        if self._subset_gdf is None:
+            # subset data
+            if self.us_river == self.ds_river and self.us_reach == self.ds_reach:
+                ripple_xs, ripple_structure, ripple_river = self.process_as_one_ras_reach()
+            else:
+                ripple_xs, ripple_structure, ripple_river = self.process_as_multiple_ras_reach()
 
-        # check if only 1 cross section for nwm_reach
-        if len(ripple_xs) <= 1:
-            logging.warning(f"Only 1 cross section conflated to NWM reach {self.nwm_id}. Skipping this reach.")
-            return None
+            # check if only 1 cross section for nwm_reach
+            if len(ripple_xs) <= 1:
+                logging.warning(f"Only 1 cross section conflated to NWM reach {self.nwm_id}. Skipping this reach.")
+                return None
 
-        # update fields
-        ripple_xs = self.update_fields(ripple_xs)
-        ripple_river = self.update_fields(ripple_river)
-        ripple_structure = self.update_fields(ripple_structure)
+            # update fields
+            ripple_xs = self.update_fields(ripple_xs)
+            ripple_river = self.update_fields(ripple_river)
+            ripple_structure = self.update_fields(ripple_structure)
 
-        # clip river to cross sections
-        ripple_river = self.clip_river(ripple_xs, ripple_river)
+            # clip river to cross sections
+            ripple_river = self.clip_river(ripple_xs, ripple_river)
 
-        if ripple_structure is not None and len(ripple_structure) > 0:
-            return {"XS": ripple_xs, "River": ripple_river, "Structure": ripple_structure}
-        else:
-            return {"XS": ripple_xs, "River": ripple_river}
+            if ripple_structure is not None and len(ripple_structure) > 0:
+                self._subset_gdf = {"XS": ripple_xs, "River": ripple_river, "Structure": ripple_structure}
+            else:
+                self._subset_gdf = {"XS": ripple_xs, "River": ripple_river}
+
+        return self._subset_gdf
 
     @property
     def ripple_gpkg_file(self) -> str:

--- a/ripple1d/ras_to_gpkg.py
+++ b/ripple1d/ras_to_gpkg.py
@@ -30,7 +30,7 @@ from ripple1d.utils.gpkg_utils import (
     reproject,
     write_thumbnail_to_s3,
 )
-from ripple1d.utils.ripple_utils import get_path, prj_is_ras, xs_concave_hull
+from ripple1d.utils.ripple_utils import fix_reversed_xs, get_path, prj_is_ras, xs_concave_hull
 from ripple1d.utils.s3_utils import (
     get_basic_object_metadata,
     init_s3_resources,
@@ -48,6 +48,7 @@ def geom_flow_to_gpkg(
     layers, metadata = geom_flow_to_gdfs(ras_project, crs, metadata, client, bucket)
     for layer, gdf in layers.items():
         if layer == "XS":
+            gdf = fix_reversed_xs(layers["XS"], layers["River"])
             if "Junction" in layers.keys():
                 xs_concave_hull(gdf, layers["Junction"]).to_file(gpkg_file, driver="GPKG", layer="XS_concave_hull")
             else:

--- a/ripple1d/utils/ripple_utils.py
+++ b/ripple1d/utils/ripple_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import glob
+import logging
 import os
 from pathlib import Path
 
@@ -10,8 +11,18 @@ import boto3
 import geopandas as gpd
 import pandas as pd
 from dotenv import find_dotenv, load_dotenv
-from shapely import Polygon, concave_hull, line_merge, make_valid, union_all
-from shapely.geometry import MultiPolygon, Point, Polygon
+from shapely import (
+    LineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
+    concave_hull,
+    line_merge,
+    make_valid,
+    reverse,
+    union_all,
+)
 
 from ripple1d.errors import (
     RASComputeError,
@@ -62,6 +73,48 @@ def get_path(expected_path: str, client: boto3.client = None, bucket: str = None
             if path.endswith(Path(expected_path).suffix.upper()):
                 return path
 
+def fix_reversed_xs(xs:gpd.GeoDataFrame,river:gpd.GeoDataFrame)->gpd.GeoDataFrame:
+    """Check if cross sections are drawn right to left looking downstream. If not reverse them."""
+    subsets=[]
+    for _,reach in river.iterrows():
+        subset_xs=xs.loc[xs["river_reach"]== reach["river_reach"]]
+        not_reversed_xs=check_xs_direction(subset_xs,reach.geometry)
+        subset_xs["geometry"]=subset_xs.apply(lambda row: row.geometry if row["river_reach_rs"] in list(not_reversed_xs["river_reach_rs"]) else reverse(row.geometry),axis=1)
+        subsets.append(subset_xs)
+    return pd.concat(subsets)
+
+def validate_point(geom):
+    """Validate that point is of type Point. If Multipoint or Linestring create point from first coordinate pair."""
+    if isinstance(geom, Point):
+        return geom
+    elif isinstance(geom, MultiPoint):
+        return geom.geoms[0]
+    elif isinstance(geom, LineString) and list(geom.coords):
+        return Point(geom.coords[0])
+    else:
+        raise TypeError(f"expected point at xs-river intersection got: {type(geom)}")
+
+def check_xs_direction(cross_sections: gpd.GeoDataFrame, reach: LineString):
+    """Return only cross sections that are drawn right to left looking downstream."""
+    river_reach_rs = []
+    for _, xs in cross_sections.iterrows():
+        try:
+            point = reach.intersection(xs["geometry"])
+            point = validate_point(point)
+            xs_rs = reach.project(point)
+
+            offset = xs.geometry.offset_curve(-1)
+            point = reach.intersection(offset)
+            point = validate_point(point)
+
+            offset_rs = reach.project(point)
+            if xs_rs > offset_rs:
+                river_reach_rs.append(xs["river_reach_rs"])
+
+        except TypeError as e:
+            logging.warning(f"could not validate xs-river intersection for: {xs["river"]} {xs['reach']} {xs['river_station']}")
+            continue
+    return cross_sections.loc[cross_sections["river_reach_rs"].isin(river_reach_rs)]
 
 def xs_concave_hull(xs: gpd.GeoDataFrame, junction: gpd.GeoDataFrame = None) -> gpd.GeoDataFrame:
     """Compute and return the concave hull (polygon) for a set of cross sections (lines all facing the same direction)."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,3 +57,4 @@ def setup_data(request):
     request.cls.min_elevation = MIN_ELEVATION
     request.cls.conflation_file = os.path.join(SOURCE_RAS_MODEL_DIRECTORY, f"{RAS_MODEL}.conflation.json")
     request.cls.crs = CRS[RAS_MODEL]
+    request.cls.FIM_LIB_DIRECTORY = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}\\fims")


### PR DESCRIPTION
Issues were introduced when a concave hull of the cross sections were produced with a source model cross section in the wrong direction causing a multipart polygon. This PR implements a check to determine if the cross sections were drawn in the correct direction and reverses the cross section if it was drawn incorrectly. This is limited to the development of the concave hull and does not modify the cross section direction for use in the modeling. This should be checked during a source model quality check that is planned for a later time. 

Closes #189