### PR TITLE
Bugfix/endpoint results

### DIFF
--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -274,7 +274,7 @@ class NwmReachModel(RasModelStructure):
     @property
     def fim_results_database(self):
         """Results database."""
-        return str(Path(self.fim_results_directory) / f"{self.model_name}.db")
+        return str(Path(self.library_directory) / f"{self.model_name}.db")
 
     @property
     def fim_rating_curve(self):

--- a/ripple1d/ops/fim_lib.py
+++ b/ripple1d/ops/fim_lib.py
@@ -204,7 +204,7 @@ def create_fim_lib(
     overviews: bool = False,
     resolution: float = 3,
     resolution_units: str = "Meters",
-    dest_crs:str=5070
+    dest_crs: str = 5070,
 ):
     """Create a new FIM library for a NWM id.
 
@@ -231,7 +231,7 @@ def create_fim_lib(
     resolution_units : str, optional
         unit for resolution, by default "Meters"
     dest_crs : str, optional
-        Destination crs. 
+        Destination crs.
 
     Returns
     -------
@@ -261,7 +261,7 @@ def create_fim_lib(
             overviews=overviews,
             resolution=resolution,
             resolution_units=resolution_units,
-            dest_crs=dest_crs
+            dest_crs=dest_crs,
         )
 
         if cleanup:

--- a/ripple1d/ops/ras_conflate.py
+++ b/ripple1d/ops/ras_conflate.py
@@ -95,20 +95,20 @@ def conflate_model(source_model_directory: str, source_network: dict):
     The spatial extents of HEC-RAS river reaches and National Water model (NWM)
     reaches are not aligned.  The conflate_model endpoint resolves these
     differences by associating HEC-RAS models and model components (e.g.
-    cross-sections) with the NWM reaches they overlap.  
+    cross-sections) with the NWM reaches they overlap.
 
     #. Generate a concave hull (bounding geometry) around the HEC-RAS source
        model cross-sections
     #. Extract NWM reaches intersecting the hull
     #. For each HEC-RAS river reach within the source model,
       #. Locate the NWM reaches nearest to the most upstream and most
-         downstream cross-sections 
+         downstream cross-sections
       #. Extract all intermediate NWM reaches by walking   the network from
          upstream to downstream
     #. For each NWM reach extracted,
-      #. Locate the HEC-RAS cross-sections that intersect the reach 
+      #. Locate the HEC-RAS cross-sections that intersect the reach
         #. Discard cross-sections that are not drawn right to left looking
-           downstream  
+           downstream
         #. If no cross-sections intersect the reach, mark the reach as
            “eclipsed”
       #. Mark the HEC-RAS cross-section closest to the upstream end of the
@@ -240,7 +240,7 @@ def conflate_model(source_model_directory: str, source_network: dict):
         logging.error(f"| Traceback: {traceback.format_exc()}")
 
     logging.info(f"conflate_model complete")
-    return conflation_file
+    return {"conflation_file": conflation_file}
 
 
 def conflated(metadata: dict) -> bool:

--- a/ripple1d/ras.py
+++ b/ripple1d/ras.py
@@ -1397,7 +1397,7 @@ def create_terrain(
         f"Running the following args, from {os.path.basename(exe_parent_dir)}:" + "\n  ".join([""] + subproc_args)
     )
     subprocess.check_call(subproc_args, cwd=exe_parent_dir, stdout=subprocess.DEVNULL)
-    return f"Terrain written to {dst_terrain_filepath}"
+    return {"RAS Terrain": dst_terrain_filepath}
 
     # TODO this recompression does work but RAS does not accept the recompressed tif for unknown reason...
     # # compress the output tif(s) that RasProcess.exe created (otherwise could be 1+ GB at HUC12 size)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def setup_data(request):
     request.cls.FLOW4_FILE = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.f04")
     request.cls.RESULT4_FILE = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.r04")
 
-    request.cls.FIM_LIB_DB = os.path.join(FIM_LIB_DIRECTORY, f"{REACH_ID}\\{REACH_ID}.db")
+    request.cls.FIM_LIB_DB = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.db")
     request.cls.DEPTH_GRIDS_ND = os.path.join(FIM_LIB_DIRECTORY, f"{REACH_ID}\\z_nd")
     integer, decimal = str(np.floor((MIN_ELEVATION + 41) * 2) / 2).split(".")
     request.cls.DEPTH_GRIDS_KWSE = os.path.join(FIM_LIB_DIRECTORY, f"{REACH_ID}\\z_{integer}_{decimal}")


### PR DESCRIPTION
This PR fixes 2 bugs:

1. Rating curves databases are now created directly in the submodel directory. 
2. All endpoints now return a dictionary as results instead of a mix of result types. 