### PR TITLE
fix cleanup

### DIFF
--- a/ripple1d/ops/fim_lib.py
+++ b/ripple1d/ops/fim_lib.py
@@ -265,7 +265,7 @@ def create_fim_lib(
         )
 
         if cleanup:
-            shutil.rmtree(os.path.join(rm.ras_project._ras_dir, f"{nwm_rm.model_name}_{plan}", ignore_errors=True))
+            shutil.rmtree(os.path.join(rm.ras_project._ras_dir, f"{nwm_rm.model_name}_{plan}"), ignore_errors=True)
 
     logging.info(f"create_fim_lib complete")
 


### PR DESCRIPTION
The ignore_errors arg for rmtree was inside the parenthesis for os.path.join. This has been fixed. 

Closes #252