### PR TITLE
Bugfix/issue 261

### DIFF
--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -295,6 +295,7 @@ def run_known_wse(
             f"No controling known water surface elevations were identified for {nwm_rm.model_name}; i.e., the depth of flooding\
  for the normal depth run for a given flow was alway higher than the known water surface elevations of the downstream reach"
         )
+        pid = None
     else:
         pid = rm.kwses_run(
             f"{nwm_rm.model_name}_{plan_suffix}",

--- a/ripple1d/ras.py
+++ b/ripple1d/ras.py
@@ -411,9 +411,8 @@ class RasManager:
             self.update_rasmapper_for_mapping()
 
         if run_ras:
-            compute_message_file = self.ras_project._ras_root_path + f"{self.plan.file_extension}.computeMsgs.txt"
             runRAS = f'C:\\Program Files (x86)\\HEC\\HEC-RAS\\6.3.1\\Ras.exe "{self.ras_project._ras_text_file_path}" \
-                "{self.ras_project._ras_root_path}{self.plan.file_extension}" -c'  # -hideCompute'
+                "{self.ras_project._ras_root_path}{self.plan.file_extension}" -c'
             p = subprocess.Popen(runRAS)
             return p.pid
 


### PR DESCRIPTION
This PR resolves #261 by defining RAS pid as None when no KWSE runs are valid and HEC-RAS is not initiated.