### PR TITLE
Feature/fix htab warning

### DIFF
--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -419,6 +419,21 @@ class XS:
             return min(y)
 
     @property
+    def has_htab_error(self):
+        """Check if min htab value is less than section invert."""
+        return self.min_htab < self.thalweg
+
+    @property
+    def htab_string(self):
+        """Cross section htab string."""
+        return search_contents(self.ras_data, "XS HTab Starting El and Incr", expect_one=True)
+
+    @property
+    def min_htab(self):
+        """Cross section minimum htab."""
+        return float(self.htab_string.split(",")[0])
+
+    @property
     def xs_max_elevation(self):
         """Cross section maximum elevation."""
         if self.station_elevation_points:

--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -422,7 +422,7 @@ class XS:
     def has_htab_error(self):
         """Check if min htab value is less than section invert."""
         if self.htab_string is None:
-            return None
+            return False
         else:
             return self.htab_starting_el < self.thalweg
 

--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -421,12 +421,19 @@ class XS:
     @property
     def has_htab_error(self):
         """Check if min htab value is less than section invert."""
-        return self.htab_starting_el < self.thalweg
+        if self.htab_string is None:
+            return None
+        else:
+            return self.htab_starting_el < self.thalweg
 
     @property
     def htab_string(self):
         """Cross section htab string."""
-        return search_contents(self.ras_data, "XS HTab Starting El and Incr", expect_one=True)
+        try:
+            htabstr = search_contents(self.ras_data, "XS HTab Starting El and Incr", expect_one=True)
+        except:
+            htabstr = None
+        return htabstr
 
     @property
     def htab_starting_el(self):

--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -421,7 +421,7 @@ class XS:
     @property
     def has_htab_error(self):
         """Check if min htab value is less than section invert."""
-        return self.min_htab < self.thalweg
+        return self.htab_starting_el < self.thalweg
 
     @property
     def htab_string(self):
@@ -429,9 +429,19 @@ class XS:
         return search_contents(self.ras_data, "XS HTab Starting El and Incr", expect_one=True)
 
     @property
-    def min_htab(self):
+    def htab_starting_el(self):
         """Cross section minimum htab."""
         return float(self.htab_string.split(",")[0])
+
+    @property
+    def htab_increment(self):
+        """Cross section minimum htab."""
+        return float(self.htab_string.split(",")[1])
+
+    @property
+    def htab_points(self):
+        """Cross section minimum htab."""
+        return float(self.htab_string.split(",")[2])
 
     @property
     def xs_max_elevation(self):

--- a/ripple1d/ras.py
+++ b/ripple1d/ras.py
@@ -878,13 +878,16 @@ class RasGeomText(RasTextFile):
             if xs.has_htab_error:
                 needs_save = True
                 logging.info(f"Fixing htab error for {xs.river_reach}")
-                old_ras_str = "\n".join(xs.ras_data)
-                old_htab = xs.htab_string
-                new_htab = xs.htab_string.replace(
-                    str(xs.min_htab), str(xs.thalweg + 0.5)
-                )  # HEC-RAS default handling of this error is to do 0.5 ft above section invert
-                new_ras_string = old_ras_str.replace(old_htab, new_htab)
-                working_string = working_string.replace(old_ras_str, new_ras_string)
+                old_htab_str = xs.htab_string
+                # HEC-RAS default handling:
+                # either 0 or 0.5 ft above section invert for the start elevation
+                # increment that will yield 20 pts between start and section max elevations
+                # We want to preserve engineer-specified increments, so we don't do that
+                new_htab_str = old_htab_str.replace(str(xs.htab_starting_el), str(xs.thalweg))
+
+                old_xs_str = "\n".join(xs.ras_data)
+                new_xs_str = old_xs_str.replace(old_htab_str, new_htab_str)
+                working_string = working_string.replace(old_xs_str, new_xs_str)
         if needs_save:
             with open(self._ras_text_file_path, "w") as f:
                 f.write(working_string)


### PR DESCRIPTION
This PR closes #249.  When a hydraulic table for a cross-section has a minimum elevation below the section invert, HEC-RAS generates a pop up warning as demonstrated in #249.  In the warning, the software specifies that any subsequent saves to the geometry file will automatically adjust the hydraulic table minimum elevation to be above the section invert.  To mimic this functionality, a new function call has been added to the RasGeomText constructor.  The call will check for any occurrences of the htab issue, adjust the minimum elevation, and overwrite the geometry file with the updated value.