### PR TITLE
Feature/update xs naming

### DIFF
--- a/ripple1d/ops/metrics.py
+++ b/ripple1d/ops/metrics.py
@@ -276,14 +276,13 @@ def compute_conflation_metrics(source_model_directory: str, source_network: dict
     src_gpkg_path = os.path.join(source_model_directory, f"{model_name}.gpkg")
     conflation_json = os.path.join(source_model_directory, f"{model_name}.conflation.json")
     conflation_parameters = json.load(open(conflation_json))
-    rgs = RippleGeopackageSubsetter(src_gpkg_path, conflation_json, "")
 
     for network_id in conflation_parameters["reaches"].keys():
         try:
             if conflation_parameters["reaches"][network_id]["eclipsed"] == True:
                 continue
 
-            rgs.set_nwm_id(network_id)
+            rgs = RippleGeopackageSubsetter(src_gpkg_path, conflation_json, network_id)
             layers = {}
             for layer, gdf in rgs.subset_gdfs.items():
                 layers[layer] = gdf.to_crs(HYDROFABRIC_CRS)

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -237,8 +237,8 @@ class RippleGeopackageSubsetter:
                 & (self.source_structure["river_station"] <= float(us_limit))
             ]
             tmp_structures["source_river_station"] = tmp_structures["river_station"]
-            new_ds_limit = self.subset_xs["river_station"].min()
-            tmp_structures["river_station"] = (tmp_structures["river_station"] - ds_limit) + new_ds_limit
+            offset = tmp_xs["source_river_station"].iloc[0] - tmp_xs["river_station"].iloc[0]
+            tmp_structures["river_station"] = tmp_structures["river_station"] - offset
             subset_structures = pd.concat([subset_structures, tmp_structures])
 
         if len(subset_structures) == 0:
@@ -393,10 +393,10 @@ class RippleGeopackageSubsetter:
         lines = ras_data.splitlines()
         data = lines[0].split(",")
         if "*" in data[1]:
-            data[1] = str(float(data[1].rstrip("*")) + rs) + "*"
+            data[1] = str(float(rs)) + "*"
             data[1] = data[1].ljust(8)
         else:
-            data[1] = str(float(data[1]) + rs).ljust(8)
+            data[1] = str(float(rs)).ljust(8)
         lines[0] = ",".join(data)
         return "\n".join(lines) + "\n"
 

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -204,7 +204,7 @@ class RippleGeopackageSubsetter:
 
     @property
     @lru_cache
-    def subset_river(self):
+    def subset_river(self) -> gpd.GeoDataFrame:
         """Trim source centerline to u/s and d/s limits and add all intermediate reaches."""
         coords = []
         subset_rivers = []
@@ -225,7 +225,7 @@ class RippleGeopackageSubsetter:
 
     @property
     @lru_cache
-    def subset_structures(self):
+    def subset_structures(self) -> gpd.GeoDataFrame | None:
         """Extract structures between u/s and d/s limits."""
         if self.source_structure is None:
             return None
@@ -334,7 +334,7 @@ class RippleGeopackageSubsetter:
         return reach_xs
 
     @lru_cache
-    def junctions_to_dicts(self):
+    def junctions_to_dicts(self) -> tuple[dict, dict]:
         """Make dicts that map trib->outflow and trib->d/s distance for all junctions."""
         juntion_tree_dict = {}
         juntion_dist_dict = {}
@@ -463,8 +463,6 @@ def extract_submodel(source_model_directory: str, submodel_directory: str, nwm_i
     FileNotFoundError
         Raised when no .conflation.json is found in the source model directory
     """
-    # time.sleep(10)
-
     if not os.path.exists(source_model_directory):
         raise FileNotFoundError(
             f"cannot find directory for source model {source_model_directory}, please ensure dir exists"
@@ -472,7 +470,6 @@ def extract_submodel(source_model_directory: str, submodel_directory: str, nwm_i
     rsd = RippleSourceDirectory(source_model_directory)
 
     logging.info(f"extract_submodel starting for nwm_id {nwm_id}")
-    # print(f"preparing to extract NWM ID {nwm_id} from {os.path.basename(rsd.ras_project_file)}")
 
     if not rsd.file_exists(rsd.ras_gpkg_file):
         raise FileNotFoundError(f"cannot find file ras-geometry file {rsd.ras_gpkg_file}, please ensure file exists")

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -3,21 +3,17 @@
 import json
 import logging
 import os
-import time
 import warnings
 from functools import lru_cache
-from re import sub
 
 import fiona
 import geopandas as gpd
 import pandas as pd
 from shapely import LineString
-from shapely.geometry import MultiLineString
 from shapely.ops import split
 
 import ripple1d
-from ripple1d.consts import METERS_PER_FOOT
-from ripple1d.data_model import NwmReachModel, RippleSourceDirectory, RippleSourceModel
+from ripple1d.data_model import NwmReachModel, RippleSourceDirectory
 from ripple1d.utils.ripple_utils import (
     clip_ras_centerline,
     fix_reversed_xs,
@@ -36,20 +32,92 @@ class RippleGeopackageSubsetter:
         self.conflation_json = conflation_json
         self.dst_project_dir = dst_project_dir
         self.nwm_id = nwm_id
-        self._subset_gdf = None
-        self._source_junction = None
-        self._source_river = None
-        self._source_xs = None
-        self._source_structure = None
-        self._conflation_parameters = None
-        self._source_hulls = None
-        self._ripple_xs_concave_hull = None
 
     def set_nwm_id(self, nwm_id: str):
         """Set the network ID."""
         self.nwm_id = nwm_id
         self._subset_gdf = None
         self._ripple_xs_concave_hull = None
+
+    @property
+    @lru_cache
+    def conflation_parameters(self) -> dict:
+        """Extract conflation parameters from the conflation json."""
+        with open(self.conflation_json, "r") as f:
+            conflation_parameters = json.load(f)
+        return conflation_parameters
+
+    @property
+    def ripple1d_parameters(self) -> dict:
+        """Extract ripple1d parameters from the conflation json."""
+        return self.conflation_parameters["reaches"][self.nwm_id]
+
+    @property
+    def us_reach(self) -> str:
+        """Extract upstream reach from conflation parameters."""
+        return self.ripple1d_parameters["us_xs"]["reach"]
+
+    @property
+    def us_river(self) -> str:
+        """Extract upstream river from conflation parameters."""
+        return self.ripple1d_parameters["us_xs"]["river"]
+
+    @property
+    def us_rs(self) -> str:
+        """Extract upstream river station from conflation parameters."""
+        return self.ripple1d_parameters["us_xs"]["xs_id"]
+
+    @property
+    def ds_river(self) -> str:
+        """Extract downstream river from conflation parameters."""
+        return self.ripple1d_parameters["ds_xs"]["river"]
+
+    @property
+    def ds_reach(self) -> str:
+        """Extract downstream reach from conflation parameters."""
+        return self.ripple1d_parameters["ds_xs"]["reach"]
+
+    @property
+    def ds_rs(self) -> str:
+        """Extract downstream river station from conflation parameters."""
+        return self.ripple1d_parameters["ds_xs"]["xs_id"]
+
+    @property
+    @lru_cache
+    def source_xs(self) -> gpd.GeoDataFrame:
+        """Extract cross sections from the source geopackage."""
+        xs = gpd.read_file(self.src_gpkg_path, layer="XS")
+        source_xs = xs[xs.intersects(self.source_river.union_all())]
+        return source_xs
+
+    @property
+    @lru_cache
+    def source_hulls(self) -> gpd.GeoDataFrame:
+        """Extract cross sections from the source geopackage."""
+        return gpd.read_file(self.src_gpkg_path, layer="XS_concave_hull")
+
+    @property
+    @lru_cache
+    def source_river(self) -> gpd.GeoDataFrame:
+        """Extract river geometry from the source geopackage."""
+        return gpd.read_file(self.src_gpkg_path, layer="River")
+
+    @property
+    @lru_cache
+    def source_structure(self) -> gpd.GeoDataFrame:
+        """Extract structures from the source geopackage."""
+        if "Structure" in fiona.listlayers(self.src_gpkg_path):
+            structures = gpd.read_file(self.src_gpkg_path, layer="Structure")
+            source_structure = structures[structures.intersects(self.source_river.union_all())]
+            return source_structure
+
+    @property
+    @lru_cache
+    def source_junction(self) -> gpd.GeoDataFrame:
+        """Extract junctions from the source geopackage."""
+        if "Junction" in fiona.listlayers(self.src_gpkg_path):
+            source_junction = gpd.read_file(self.src_gpkg_path, layer="Junction")
+            return source_junction
 
     @property
     def ripple_us_xs(self):
@@ -93,92 +161,6 @@ class RippleGeopackageSubsetter:
                 self._ripple_xs_concave_hull = xs_concave_hull(fix_reversed_xs(self.ripple_xs, self.ripple_river))
 
         return self._ripple_xs_concave_hull
-
-    @property
-    def conflation_parameters(self) -> dict:
-        """Extract conflation parameters from the conflation json."""
-        if self._conflation_parameters is None:
-            with open(self.conflation_json, "r") as f:
-                self._conflation_parameters = json.load(f)
-        return self._conflation_parameters
-
-    @property
-    def ripple1d_parameters(self) -> dict:
-        """Extract ripple1d parameters from the conflation json."""
-        return self.conflation_parameters["reaches"][self.nwm_id]
-
-    @property
-    def us_reach(self) -> str:
-        """Extract upstream reach from conflation parameters."""
-        return self.ripple1d_parameters["us_xs"]["reach"]
-
-    @property
-    def us_river(self) -> str:
-        """Extract upstream river from conflation parameters."""
-        return self.ripple1d_parameters["us_xs"]["river"]
-
-    @property
-    def us_rs(self) -> str:
-        """Extract upstream river station from conflation parameters."""
-        return self.ripple1d_parameters["us_xs"]["xs_id"]
-
-    @property
-    def ds_river(self) -> str:
-        """Extract downstream river from conflation parameters."""
-        return self.ripple1d_parameters["ds_xs"]["river"]
-
-    @property
-    def ds_reach(self) -> str:
-        """Extract downstream reach from conflation parameters."""
-        return self.ripple1d_parameters["ds_xs"]["reach"]
-
-    @property
-    def ds_rs(self) -> str:
-        """Extract downstream river station from conflation parameters."""
-        return self.ripple1d_parameters["ds_xs"]["xs_id"]
-
-    @property
-    def source_xs(self) -> gpd.GeoDataFrame:
-        """Extract cross sections from the source geopackage."""
-        if self._source_xs is None:
-            xs = gpd.read_file(self.src_gpkg_path, layer="XS")
-            self._source_xs = xs[xs.intersects(self.source_river.union_all())]
-        return self._source_xs
-
-    @property
-    def source_hulls(self) -> gpd.GeoDataFrame:
-        """Extract cross sections from the source geopackage."""
-        if self._source_hulls is None:
-            # TODO we can read the concave hull of the source model from the gpkg once we decide that it is required layer.
-            # self._source_hulls = gpd.read_file(self.src_gpkg_path, layer="XS_concave_hull")
-            self._source_hulls = xs_concave_hull(
-                fix_reversed_xs(self.source_xs, self.source_river), self.source_junction
-            )
-        return self._source_hulls
-
-    @property
-    def source_river(self) -> gpd.GeoDataFrame:
-        """Extract river geometry from the source geopackage."""
-        if self._source_river is None:
-            self._source_river = gpd.read_file(self.src_gpkg_path, layer="River")
-        return self._source_river
-
-    @property
-    def source_structure(self) -> gpd.GeoDataFrame:
-        """Extract structures from the source geopackage."""
-        if "Structure" in fiona.listlayers(self.src_gpkg_path):
-            if self._source_structure is None:
-                structures = gpd.read_file(self.src_gpkg_path, layer="Structure")
-                self._source_structure = structures[structures.intersects(self.source_river.union_all())]
-            return self._source_structure
-
-    @property
-    def source_junction(self) -> gpd.GeoDataFrame:
-        """Extract junctions from the source geopackage."""
-        if "Junction" in fiona.listlayers(self.src_gpkg_path):
-            if self._source_junction is None:
-                self._source_junction = gpd.read_file(self.src_gpkg_path, layer="Junction")
-            return self._source_junction
 
     @property
     def juntion_tree_dict(self) -> dict:
@@ -270,6 +252,75 @@ class RippleGeopackageSubsetter:
         else:
             return gpd.GeoDataFrame(subset_structures)
 
+    @property
+    @lru_cache
+    def subset_gdfs(self) -> dict:
+        """Subset the cross sections, structues, and river geometry for a given NWM reach."""
+        # subset geometry data
+        subset_gdfs = {}
+        subset_gdfs["XS"] = self.subset_xs
+        if len(subset_gdfs["XS"]) <= 1:  # check if only 1 cross section for nwm_reach
+            logging.warning(f"Only 1 cross section conflated to NWM reach {self.nwm_id}. Skipping this reach.")
+            return None
+        subset_gdfs["River"] = self.subset_river
+        if self.subset_structures is not None:
+            subset_gdfs["Structure"] = self.subset_structures
+
+        # Update fields
+        for k in subset_gdfs:
+            subset_gdfs[k] = self.rename_river_reach(subset_gdfs[k])
+        subset_gdfs = self.update_river_station(subset_gdfs)
+
+        return subset_gdfs
+
+    @property
+    def ripple_xs(self) -> gpd.GeoDataFrame:
+        """Subset cross sections based on NWM reach."""
+        return self.subset_gdfs["XS"]
+
+    @property
+    def ripple_river(self) -> gpd.GeoDataFrame:
+        """Subset river geometry based on NWM reach."""
+        return self.subset_gdfs["River"]
+
+    @property
+    def ripple_structure(self) -> gpd.GeoDataFrame:
+        """Subset structures based on NWM reach."""
+        return self.subset_gdfs["Structure"]
+
+    @property
+    def ripple_gpkg_file(self) -> str:
+        """Return the path to the new geopackage."""
+        return self.nwm_reach_model.ras_gpkg_file
+
+    @property
+    def nwm_reach_model(self) -> NwmReachModel:
+        """Return the new NWM reach model object."""
+        return NwmReachModel(self.dst_project_dir)
+
+    @property
+    def min_flow(self) -> float:
+        """Extract the min flow from the cross sections."""
+        if "flows" in self.ripple_xs.columns:
+            return self.ripple_xs["flows"].str.split("\n", expand=True).astype(float).min().min()
+        else:
+            logging.warning(f"no flows specified in source model gpkg for {self.nwm_id}")
+            return 10000000000000
+
+    @property
+    def max_flow(self) -> float:
+        """Extract the max flow from the cross sections."""
+        if "flows" in self.ripple_xs.columns:
+            return self.ripple_xs["flows"].str.split("\n", expand=True).astype(float).max().max()
+        else:
+            logging.warning(f"no flows specified in source model gpkg for {self.nwm_id}")
+            return 0
+
+    @property
+    def crs(self):
+        """Extract the CRS from the cross sections."""
+        return self.source_xs.crs
+
     def trim_reach(self, reach_xs: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         """Trim a reach-specific XS gdf to the u/s and d/s limits."""
         # Trim
@@ -302,52 +353,6 @@ class RippleGeopackageSubsetter:
 
         return (juntion_tree_dict, juntion_dist_dict)
 
-    @property
-    def ripple_xs(self) -> gpd.GeoDataFrame:
-        """Subset cross sections based on NWM reach."""
-        return self.subset_gdfs["XS"]
-
-    @property
-    def ripple_river(self) -> gpd.GeoDataFrame:
-        """Subset river geometry based on NWM reach."""
-        return self.subset_gdfs["River"]
-
-    @property
-    def ripple_structure(self) -> gpd.GeoDataFrame:
-        """Subset structures based on NWM reach."""
-        return self.subset_gdfs["Structure"]
-
-    @property
-    @lru_cache
-    def subset_gdfs(self) -> dict:
-        """Subset the cross sections, structues, and river geometry for a given NWM reach."""
-        # subset geometry data
-        subset_gdfs = {}
-        subset_gdfs["XS"] = self.subset_xs
-        if len(subset_gdfs["XS"]) <= 1:  # check if only 1 cross section for nwm_reach
-            logging.warning(f"Only 1 cross section conflated to NWM reach {self.nwm_id}. Skipping this reach.")
-            return None
-        subset_gdfs["River"] = self.subset_river
-        if self.subset_structures is not None:
-            subset_gdfs["Structure"] = self.subset_structures
-
-        # Update fields
-        for k in subset_gdfs:
-            subset_gdfs[k] = self.rename_river_reach(subset_gdfs[k])
-        subset_gdfs = self.update_river_station(subset_gdfs)
-
-        return subset_gdfs
-
-    @property
-    def ripple_gpkg_file(self) -> str:
-        """Return the path to the new geopackage."""
-        return self.nwm_reach_model.ras_gpkg_file
-
-    @property
-    def nwm_reach_model(self) -> NwmReachModel:
-        """Return the new NWM reach model object."""
-        return NwmReachModel(self.dst_project_dir)
-
     def write_ripple_gpkg(self) -> None:
         """Write the subsetted geopackage to the destination project directory."""
         os.makedirs(self.dst_project_dir, exist_ok=True)
@@ -365,77 +370,6 @@ class RippleGeopackageSubsetter:
                 gdf.to_file(self.ripple_gpkg_file, layer=layer)
                 if layer == "XS":
                     self.ripple_xs_concave_hull.to_file(self.ripple_gpkg_file, driver="GPKG", layer="XS_concave_hull")
-
-    @property
-    def min_flow(self) -> float:
-        """Extract the min flow from the cross sections."""
-        if "flows" in self.ripple_xs.columns:
-            return self.ripple_xs["flows"].str.split("\n", expand=True).astype(float).min().min()
-        else:
-            logging.warning(f"no flows specified in source model gpkg for {self.nwm_id}")
-            return 10000000000000
-
-    @property
-    def max_flow(self) -> float:
-        """Extract the max flow from the cross sections."""
-        if "flows" in self.ripple_xs.columns:
-            return self.ripple_xs["flows"].str.split("\n", expand=True).astype(float).max().max()
-        else:
-            logging.warning(f"no flows specified in source model gpkg for {self.nwm_id}")
-            return 0
-
-    @property
-    def crs(self):
-        """Extract the CRS from the cross sections."""
-        return self.source_xs.crs
-
-    def walk_junctions(self) -> list[str]:
-        """Walk the junctions to find reaches between u/s and d/s reach."""
-        if self.source_junction is None:
-            return
-
-        # make a tree dictionary
-        tree_dict = {}
-        for r in self.source_junction.iterrows():
-            trib_rivers = r[1]["us_rivers"].split(",")
-            trib_reaches = r[1]["us_reaches"].split(",")
-            outlet = f'{r[1]["ds_rivers"]}-{r[1]["ds_reaches"]}'
-            for riv, rch in zip(trib_rivers, trib_reaches):
-                tree_dict[f"{riv}-{rch}"] = outlet
-
-        # walk network to id intermediate reaches
-        intermediate_reaches = []
-        cur_reach = f"{self.us_river}-{self.us_reach}"
-        ds_reach = f"{self.ds_river}-{self.ds_reach}"
-        while cur_reach != ds_reach:
-            cur_reach = tree_dict[cur_reach]
-            intermediate_reaches.append(cur_reach)
-        intermediate_reaches = intermediate_reaches[:-1]  # remove d/s reach
-        return intermediate_reaches
-
-    def clean_river_stations(self, ras_data: str) -> str:
-        """Clean up river station data."""
-        lines = ras_data.splitlines()
-        data = lines[0].split(",")
-        if "*" in data[1]:
-            data[1] = str(float(data[1].rstrip("*"))) + "*"
-            data[1] = data[1].ljust(8)
-        else:
-            data[1] = str(float(data[1])).ljust(8)
-        lines[0] = ",".join(data)
-        return "\n".join(lines) + "\n"
-
-    def round_river_stations(self, ras_data: str) -> str:
-        """Clean up river station data."""
-        lines = ras_data.splitlines()
-        data = lines[0].split(",")
-        if "*" in data[1]:
-            data[1] = str(float(round(float(data[1].rstrip("*"))))) + "*"
-            data[1] = data[1].ljust(8)
-        else:
-            data[1] = str(float(round(float(data[1])))).ljust(8)
-        lines[0] = ",".join(data)
-        return "\n".join(lines) + "\n"
 
     def update_river_station(self, subset_gdfs: dict[gpd.GeoDataFrame]) -> dict:
         """Convert river stations to autoincrementing names."""
@@ -472,140 +406,6 @@ class RippleGeopackageSubsetter:
         lines[0] = ",".join(data)
         return "\n".join(lines) + "\n"
 
-    def junction_length_to_reach_lengths(self):
-        """Adjust reach lengths using junction."""
-        # TODO adjust reach lengths using junction lengths
-        raise NotImplementedError
-        # for row in junction_gdf.iterrows():
-        #     if us_river in row["us_rivers"] and us_reach in row["us_reach"]:
-
-    def process_as_one_ras_reach(self) -> tuple:
-        """Process as a single ras-river-reach."""
-        xs_subset_gdf = self.source_xs.loc[
-            (self.source_xs["river"] == self.us_river)
-            & (self.source_xs["reach"] == self.us_reach)
-            & (self.source_xs["river_station"] >= float(self.ds_rs))
-            & (self.source_xs["river_station"] <= float(self.us_rs))
-        ]
-        if self.source_structure is not None:
-            structures_subset_gdf = self.source_structure.loc[
-                (self.source_structure["river"] == self.us_river)
-                & (self.source_structure["reach"] == self.us_reach)
-                & (self.source_structure["river_station"] >= float(self.ds_rs))
-                & (self.source_structure["river_station"] <= float(self.us_rs))
-            ]
-        else:
-            structures_subset_gdf = None
-        river_subset_gdf = self.source_river.loc[
-            (self.source_river["river"] == self.us_river) & (self.source_river["reach"] == self.us_reach)
-        ]
-
-        return xs_subset_gdf, structures_subset_gdf, river_subset_gdf
-
-    @property
-    def xs_us_reach(self) -> gpd.GeoDataFrame:
-        """Extract cross sections for the upstream reach."""
-        return self.source_xs.loc[
-            (self.source_xs["river"] == self.us_river)
-            & (self.source_xs["reach"] == self.us_reach)
-            & (self.source_xs["river_station"] <= float(self.us_rs))
-        ]
-
-    @property
-    def xs_ds_reach(self) -> gpd.GeoDataFrame:
-        """Extract cross sections for the downstream reach."""
-        return self.source_xs.loc[
-            (self.source_xs["river"] == self.ds_river)
-            & (self.source_xs["reach"] == self.ds_reach)
-            & (self.source_xs["river_station"] >= float(self.ds_rs))
-        ]
-
-    @property
-    def structures_us_reach(self) -> gpd.GeoDataFrame:
-        """Extract structures for the upstream reach."""
-        if self.source_structure is not None:
-            return self.source_structure.loc[
-                (self.source_structure["river"] == self.us_river)
-                & (self.source_structure["reach"] == self.us_reach)
-                & (self.source_structure["river_station"] <= float(self.us_rs))
-            ]
-
-    @property
-    def structures_ds_reach(self) -> gpd.GeoDataFrame:
-        """Extract structures for the downstream reach."""
-        if self.source_structure is not None:
-            return self.source_structure.loc[
-                (self.source_structure["river"] == self.ds_river)
-                & (self.source_structure["reach"] == self.ds_reach)
-                & (self.source_structure["river_station"] >= float(self.ds_rs))
-            ]
-
-    def add_intermediate_river_reaches(self, intermediate_river_reaches) -> gpd.GeoDataFrame:
-        """Add intermediate river reaches to the xs_us_reach."""
-        xs_us_reach = self.xs_us_reach.copy()
-        for intermediate_river_reach in intermediate_river_reaches:
-            xs_intermediate_river_reach = self.source_xs.loc[self.source_xs["river_reach"] == intermediate_river_reach]
-            if xs_us_reach["river_station"].min() <= xs_intermediate_river_reach["river_station"].max():
-                logging.info(
-                    f"The lowest river station on the upstream reach ({xs_us_reach['river_station'].min()}) is less"
-                    f" than the highest river station on the intermediate reach"
-                    f"({xs_intermediate_river_reach['river_station'].max()}) for nwm_id: {self.nwm_id}. The river"
-                    f" stationing of the upstream reach will be updated to ensure river stationings increase from"
-                    "downstream to upstream"
-                )
-                xs_us_reach["river_station"] = (
-                    xs_us_reach["river_station"] + xs_intermediate_river_reach["river_station"].max()
-                )
-                xs_us_reach["ras_data"] = xs_us_reach["ras_data"].apply(
-                    lambda ras_data: self.update_river_station(
-                        ras_data, xs_intermediate_river_reach["river_station"].max()
-                    )
-                )
-            xs_us_reach = pd.concat([xs_us_reach, xs_intermediate_river_reach])
-        return xs_us_reach
-
-    def adjust_river_stations(self, xs_us_reach, structures_us_reach) -> tuple:
-        """Adjust river stations of the upstream reach if the min river station of the upstream reach is less than the max river station of the downstream reach."""
-        if xs_us_reach["river_station"].min() <= self.xs_ds_reach["river_station"].max():
-            logging.info(
-                f"the lowest river station on the upstream reach ({xs_us_reach['river_station'].min()}) is less"
-                f" than the highest river station on the downstream reach ({self.xs_ds_reach['river_station'].max()}) for nwm_id: {self.nwm_id}"
-            )
-            xs_us_reach["river_station"] = xs_us_reach["river_station"] + self.xs_ds_reach["river_station"].max()
-            xs_us_reach["ras_data"] = xs_us_reach["ras_data"].apply(
-                lambda ras_data: self.update_river_station(ras_data, self.xs_ds_reach["river_station"].max())
-            )
-            if structures_us_reach is not None:
-                structures_us_reach["river_station"] = (
-                    structures_us_reach["river_station"] + self.xs_ds_reach["river_station"].max()
-                )
-                structures_us_reach["ras_data"] = structures_us_reach["ras_data"].apply(
-                    lambda ras_data: self.update_river_station(ras_data, self.xs_ds_reach["river_station"].max())
-                )
-        return xs_us_reach, structures_us_reach
-
-    def process_as_multiple_ras_reach(self) -> tuple:
-        """Process as multiple ras-river-reach."""
-        # add intermediate river reaches to the upstream reach
-        intermediate_river_reaches = self.walk_junctions()
-        if intermediate_river_reaches:
-            xs_us_reach = self.add_intermediate_river_reaches(intermediate_river_reaches)
-        else:
-            xs_us_reach = self.xs_us_reach.copy()
-
-        # update river stations
-        xs_us_reach, structures_us_reach = self.adjust_river_stations(xs_us_reach, self.structures_us_reach)
-        # combine us and ds gdfs
-        xs_subset_gdf = pd.concat([xs_us_reach, self.xs_ds_reach])
-        river_subset_gdf = self.combine_reach_features(intermediate_river_reaches)
-
-        if self.source_structure is not None:
-            structures_subset_gdf = pd.concat([structures_us_reach, self.structures_ds_reach])
-        else:
-            structures_subset_gdf = None
-
-        return xs_subset_gdf, structures_subset_gdf, river_subset_gdf
-
     def rename_river_reach(self, gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         """Rename river, reach, and river_reach columns after the nwm reach id."""
         pd.options.mode.copy_on_write = True
@@ -613,47 +413,6 @@ class RippleGeopackageSubsetter:
         gdf["reach"] = self.nwm_id
         gdf["river_reach"] = f"{self.nwm_id.ljust(16)},{self.nwm_id.ljust(16)}"
 
-        return gdf
-
-    def combine_reach_features(self, intermediate_river_reaches: list[str]) -> gpd.GeoDataFrame:
-        """Combine reach coordinates and update river and reach names to be nwm id."""
-        us_reach = self.source_river.loc[
-            (self.source_river["river"] == self.us_river) & (self.source_river["reach"] == self.us_reach)
-        ]
-        ds_reach = self.source_river.loc[
-            (self.source_river["river"] == self.ds_river) & (self.source_river["reach"] == self.ds_reach)
-        ]
-
-        # handle river reach coords
-        coords = list(us_reach.iloc[0]["geometry"].coords)
-        if intermediate_river_reaches:
-            for intermediate_river_reach in intermediate_river_reaches:
-                intermediate_river_reach_reach = self.source_river.loc[
-                    self.source_river["river_reach"] == intermediate_river_reach
-                ]
-                coords += list(intermediate_river_reach_reach.iloc[0]["geometry"].coords)
-        coords += list(ds_reach.iloc[0]["geometry"].coords)
-
-        return gpd.GeoDataFrame(
-            {"geometry": [LineString(coords)], "river": [self.nwm_id], "reach": [self.nwm_id]},
-            geometry="geometry",
-            crs=self.crs,
-        )
-
-    def autoincrement_stations(self, gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
-        """Update river_stations and ras data to be autoincrementing instead of distances."""
-        gdf["river_station"] = range(1, len(gdf) + 1)  # autoincrementing field
-        for row in gdf.iterrows():  # for each XS
-            # update station name in RAS data
-            ras_data = row[1]["ras_data"]
-            lines = ras_data.splitlines()
-            data = lines[0].split(",")
-            if "*" in data[1]:
-                data[1] = str(row[1]["river_station"] + "*").ljust(8)
-            else:
-                data[1] = str(row[1]["river_station"]).ljust(8)
-            lines[0] = ",".join(data)
-            gdf.loc[row[0], "ras_data"] = "\n".join(lines) + "\n"
         return gdf
 
     def update_ripple1d_parameters(self, rsd: RippleSourceDirectory):

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -33,12 +33,6 @@ class RippleGeopackageSubsetter:
         self.dst_project_dir = dst_project_dir
         self.nwm_id = nwm_id
 
-    def set_nwm_id(self, nwm_id: str):
-        """Set the network ID."""
-        self.nwm_id = nwm_id
-        self._subset_gdf = None
-        self._ripple_xs_concave_hull = None
-
     @property
     @lru_cache
     def conflation_parameters(self) -> dict:


### PR DESCRIPTION
This PR closes #225 and #266 by changing the naming convention for sub model cross-sections.  Cross-section names for a sub model are now auto-incremented (ex 1, 2, 3, etc) instead of reflecting the model station.

Additionally, the extract_submodel endpoint has been refactored to fix a potential bug in the junction walking step.  For cases where more than one junction separated the u/s and d/s cross-sections or cases where the junctions were not reported from upstream to downstream in the HEC-RAS geometry file, the extract_submodel endpoint would only grab a single intermediate reach.  No examples of this behavior have been found in production, but the bug was tested in development with a testing HEC-RAS model.