### PR TITLE
Bugfix/python 3 12 8

### DIFF
--- a/ripple1d/api/manager.py
+++ b/ripple1d/api/manager.py
@@ -47,7 +47,7 @@ class RippleManager:
         if sys.platform != "win32":
             raise SystemError("API can only be run from a windows system")
 
-        huey_consumer_path = shutil.which("huey_consumer.py")
+        huey_consumer_path = os.path.join(os.path.dirname(sys.executable), "huey_consumer.py")
 
         if not huey_consumer_path:
             print("Error: huey consumer script was not discoverable.")

--- a/ripple1d/utils/sqlite_utils.py
+++ b/ripple1d/utils/sqlite_utils.py
@@ -41,7 +41,7 @@ def insert_data(
 
     for row in data.itertuples():
         if boundary_condition == "kwse":
-            if f"f_{int(row.us_flow)}-z_{str(row.ds_wse).replace(".","_")}" in missing_grids:
+            if f'f_{int(row.us_flow)}-z_{str(row.ds_wse).replace(".","_")}' in missing_grids:
                 map_exist = 0
             else:
                 map_exist = 1


### PR DESCRIPTION
This PR resolves #271.  As of Python 3.12.8, shutil.which() will only identify files with an extension listed in the environmental variable PATHEXT. .py files are not in this list by default. https://github.com/python/cpython/issues/127001

line 50 of manager.py uses shutil.which() to locate the full path to huey_consumer.py. Under 3.12.8, this will return None, and ripple with return exit code 1: Error: huey consumer script was not discoverable.

This PR addresses the issue by using the directory of the sys.executable to locate the huey consumer file.

Furthermore, python 3.12.8 appears to be raising an error on an f-string that was not being raised in earlier versions.  Taking this opportunity to clean the f-string up.