### PR TITLE
catch and raise error when downloaded terrain is all nodata.

### DIFF
--- a/ripple1d/errors.py
+++ b/ripple1d/errors.py
@@ -100,3 +100,7 @@ class PlanNameNotFoundError(Exception):
 
 class UnknownVerticalUnits(Exception):
     """Raised when unknown vertical units are specified."""
+
+
+class NullTerrainError(Exception):
+    """Raised when the downloaded terrain for an error is all nodata values."""


### PR DESCRIPTION
Resolves #281 by checking whether a downloaded raster contains all nodata values and raising an informative error if it does not.