### PR TITLE
Bugfix/reversed reach conflation

### DIFF
--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -704,7 +704,7 @@ def validate_reach_conflation(reach_xs_data: dict, reach_id: str):
     us = reach_xs_data["us_xs"]
     ds = reach_xs_data["ds_xs"]
     if (us["river"] == ds["river"]) & (us["reach"] == ds["reach"]) & (us["xs_id"] < ds["xs_id"]):
-        err_str = f"Reach {reach_id} has u/s xs station ({us["xs_id"]}) lower than d/s xs station ({ds["xs_id"]})"
+        err_str = f"Reach {reach_id} has u/s xs station ({us['xs_id']}) lower than d/s xs station ({ds['xs_id']})"
         raise BadConflation(err_str)
 
 

--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -18,6 +18,7 @@ from shapely import LineString, MultiLineString, MultiPoint, Point, Polygon, box
 from shapely.ops import linemerge, nearest_points, split, transform
 
 from ripple1d.consts import METERS_PER_FOOT
+from ripple1d.errors import BadConflation
 from ripple1d.utils.ripple_utils import (
     check_xs_direction,
     clip_ras_centerline,
@@ -694,6 +695,19 @@ def map_reach_xs(rfc: RasFimConflater, reach: MultiLineString) -> dict:
     return {"us_xs": us_data, "ds_xs": ds_data, "eclipsed": False}
 
 
+def validate_reach_conflation(reach_xs_data: dict, reach_id: str):
+    """Raise error for invalid conflation.
+
+    The trim_reach method in subset_gpkg.py will return an empty geodataframe when u/s xs_id is lower than d/s xs_id.
+    This likely indicates poor CRS inference.
+    """
+    us = reach_xs_data["us_xs"]
+    ds = reach_xs_data["ds_xs"]
+    if (us["river"] == ds["river"]) & (us["reach"] == ds["reach"]) & (us["xs_id"] < ds["xs_id"]):
+        err_str = f"Reach {reach_id} has u/s xs station ({us["xs_id"]}) lower than d/s xs station ({ds["xs_id"]})"
+        raise BadConflation(err_str)
+
+
 def ras_reaches_metadata(rfc: RasFimConflater, candidate_reaches: gpd.GeoDataFrame, river_reach_name: str):
     """Return the metadata for the RAS reaches."""
     reach_metadata = OrderedDict()
@@ -702,6 +716,7 @@ def ras_reaches_metadata(rfc: RasFimConflater, candidate_reaches: gpd.GeoDataFra
         try:
             # get the xs data for the reach
             ras_xs_data = map_reach_xs(rfc, reach)
+            validate_reach_conflation(ras_xs_data, str(reach.ID))
             reach_metadata[reach.ID] = ras_xs_data
         except Exception as e:
             logging.error(f"river-reach: {river_reach_name} | network id: {reach.ID} | Error: {e}")

--- a/ripple1d/errors.py
+++ b/ripple1d/errors.py
@@ -104,3 +104,7 @@ class UnknownVerticalUnits(Exception):
 
 class BadConflation(Exception):
     """Raised when conflation yields a d/s cross-section with higher station than the u/s cross-section."""
+
+
+class SingleXSModel(Exception):
+    """Raised when geopackage creation would yield a single cross-section model."""

--- a/ripple1d/errors.py
+++ b/ripple1d/errors.py
@@ -100,3 +100,7 @@ class PlanNameNotFoundError(Exception):
 
 class UnknownVerticalUnits(Exception):
     """Raised when unknown vertical units are specified."""
+
+
+class BadConflation(Exception):
+    """Raised when conflation yields a d/s cross-section with higher station than the u/s cross-section."""

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -255,7 +255,7 @@ class RippleGeopackageSubsetter:
         subset_gdfs = {}
         subset_gdfs["XS"] = self.subset_xs
         if len(subset_gdfs["XS"]) <= 1:  # check if only 1 cross section for nwm_reach
-            err_string = f"Sub model for {self.nwm_id} would have {len(subset_gdfs["XS"])} cross-sections but is not tagged as eclipsed. Skipping."
+            err_string = f"Sub model for {self.nwm_id} would have {len(subset_gdfs['XS'])} cross-sections but is not tagged as eclipsed. Skipping."
             logging.warning(err_string)
             raise SingleXSModel(err_string)
         subset_gdfs["River"] = self.subset_river

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -14,6 +14,7 @@ from shapely.ops import split
 
 import ripple1d
 from ripple1d.data_model import NwmReachModel, RippleSourceDirectory
+from ripple1d.errors import SingleXSModel
 from ripple1d.utils.ripple_utils import (
     clip_ras_centerline,
     fix_reversed_xs,
@@ -254,8 +255,9 @@ class RippleGeopackageSubsetter:
         subset_gdfs = {}
         subset_gdfs["XS"] = self.subset_xs
         if len(subset_gdfs["XS"]) <= 1:  # check if only 1 cross section for nwm_reach
-            logging.warning(f"Only 1 cross section conflated to NWM reach {self.nwm_id}. Skipping this reach.")
-            return None
+            err_string = f"Sub model for {self.nwm_id} would have {len(subset_gdfs["XS"])} cross-sections but is not tagged as eclipsed. Skipping."
+            logging.warning(err_string)
+            raise SingleXSModel(err_string)
         subset_gdfs["River"] = self.subset_river
         if self.subset_structures is not None:
             subset_gdfs["Structure"] = self.subset_structures
@@ -476,6 +478,7 @@ def extract_submodel(source_model_directory: str, submodel_directory: str, nwm_i
         ripple1d_parameters["messages"] = f"skipping {nwm_id}; no cross sections conflated."
         logging.warning(ripple1d_parameters["messages"])
         gpkg_path = None
+        conflation_file = None
 
     else:
         rgs = RippleGeopackageSubsetter(rsd.ras_gpkg_file, rsd.conflation_file, submodel_directory, nwm_id)
@@ -483,6 +486,7 @@ def extract_submodel(source_model_directory: str, submodel_directory: str, nwm_i
         ripple1d_parameters = rgs.update_ripple1d_parameters(rsd)
         rgs.write_ripple1d_parameters(ripple1d_parameters)
         gpkg_path = rgs.ripple_gpkg_file
+        conflation_file = rsd.conflation_file
 
     logging.info(f"extract_submodel complete for nwm_id {nwm_id}")
-    return {"ripple1d_parameters": rsd.conflation_file, "ripple_gpkg_file": gpkg_path}
+    return {"ripple1d_parameters": conflation_file, "ripple_gpkg_file": gpkg_path}


### PR DESCRIPTION
Resolves #298 by raising an error (`BadConflation`) in the conflation step when a conflated NWM reach would have an upstream cross-section with station lower than the downstream cross-section.  This typically occurs when poor CRS inference has placed a model in the incorrect spot.  

This bug was originally noticed when various sub models failed to extract.  To add redundancy, a more informative error has been added to the extract submodel step.  A `SingleXSModel` exception will now be raised and describe whether sub model extraction was attempted on a single or zero cross-section model.