### PR TITLE
Feature/model name

### DIFF
--- a/ripple1d/api/postman_collection.json
+++ b/ripple1d/api/postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "f66543a1-8adc-4939-8fd0-5d6057627f7a",
+		"_postman_id": "977032b0-6c0b-4437-9347-7061b817bdae",
 		"name": "ripple1d",
 		"description": "Collection for processing existing HEC-RAS models for use in the production of Flood Inundation Maps (FIMs) and rating curves for use in near-real time flood forecasting on the NOAA National Water Model",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "11115435"
+		"_exporter_id": "29128857"
 	},
 	"item": [
 		{
@@ -75,7 +75,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"source_model_directory\": \"{{source_model_directory}}\",\r\n    \"source_network\": {\"file_name\":\"{{nwm_data_directory}}\\\\flows.parquet\",\r\n                        \"version\":\"2.1\",  // optional\r\n                        \"type\":\"nwm_hydrofabric\"}\r\n    \r\n}",
+							"raw": "{\r\n    \"source_model_directory\": \"{{source_model_directory}}\",\r\n    \"model_name\":\"{{source_model_name}}\",\r\n    \"source_network\": {\"file_name\":\"{{nwm_data_directory}}\\\\flows.parquet\",\r\n                        \"version\":\"2.1\",  // optional\r\n                        \"type\":\"nwm_hydrofabric\"}\r\n    \r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -546,8 +546,7 @@
 					"variable": [
 						{
 							"key": "jobID",
-							"value": "",
-							"type": "string"
+							"value": ""
 						}
 					]
 				},
@@ -592,8 +591,7 @@
 					"variable": [
 						{
 							"key": "jobID",
-							"value": "",
-							"type": "string"
+							"value": ""
 						}
 					]
 				},
@@ -638,8 +636,7 @@
 					"variable": [
 						{
 							"key": "jobID",
-							"value": "",
-							"type": "string"
+							"value": ""
 						}
 					]
 				},
@@ -736,6 +733,11 @@
 		{
 			"key": "nwm_data_directory",
 			"value": "~\\\\repos\\\\ripple1d\\\\tests\\\\nwm-data",
+			"type": "string"
+		},
+		{
+			"key": "source_model_name",
+			"value": "Baxter",
 			"type": "string"
 		}
 	]

--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -65,9 +65,10 @@ class RasFimConflater:
     Conflate NWM and RAS data for a single river reach.
 
     Args:
-        nwm_parquet (str): Path to the NWM Parquet file converted to parquet from:
+        nwm_pq (str): Path to the NWM Parquet file converted to parquet from:
             s3://noaa-nws-owp-fim/rasfim/inputs/X-National_Datasets/nwm_flows.gpkg
-        ras_gpkg (str): Path to the RAS GeoPackage
+        source_model_directory (str): Path to the Source HEC-RAS model directory.
+        ras_model_name (str): Name of the HEC-RAS model.
         load_data (bool, optional): Load the data on initialization. Defaults to True.
 
     Raises
@@ -77,11 +78,16 @@ class RasFimConflater:
     """
 
     def __init__(
-        self, nwm_pq: str, source_model_directory: str, load_data: bool = True, output_concave_hull_path: str = None
+        self,
+        nwm_pq: str,
+        source_model_directory: str,
+        ras_model_name: str,
+        load_data: bool = True,
+        output_concave_hull_path: str = None,
     ):
         self.nwm_pq = nwm_pq
         self.source_model_directory = source_model_directory
-        self.ras_model_name = os.path.basename(source_model_directory)
+        self.ras_model_name = ras_model_name
         self.ras_gpkg = os.path.join(source_model_directory, f"{self.ras_model_name}.gpkg")
 
         self.output_concave_hull_path = output_concave_hull_path

--- a/ripple1d/ops/ras_conflate.py
+++ b/ripple1d/ops/ras_conflate.py
@@ -58,7 +58,7 @@ def conflate_single_nwm_reach(rfc: RasFimConflater, nwm_reach_id: int):
         raise ValueError(f"nwm_reach_id {nwm_reach_id} not conflating to the ras model geometry.")
 
 
-def conflate_model(source_model_directory: str, source_network: dict):
+def conflate_model(source_model_directory: str, model_name: str, source_network: dict):
     """Conflate a HEC-RAS model with NWM reaches.
 
     Parameters
@@ -66,6 +66,8 @@ def conflate_model(source_model_directory: str, source_network: dict):
     source_model_directory : str
         The path to the directory containing HEC-RAS project, plan, geometry,
         and flow files.
+    model_name : str
+        The name of the HEC-RAS model.
     source_network : dict
         Information on the network to conflate
 
@@ -137,7 +139,7 @@ def conflate_model(source_model_directory: str, source_network: dict):
 
     version = source_network.get("version", "")
 
-    rfc = RasFimConflater(nwm_pq_path, source_model_directory)
+    rfc = RasFimConflater(nwm_pq_path, source_model_directory, model_name)
     metadata = {"reaches": {}}
     buffer = 1000
     for river_reach_name in rfc.ras_river_reach_names:

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -72,6 +72,7 @@ class TestPreprocessAPI(unittest.TestCase):
     def test_b_conflation(self):
         payload = {
             "source_model_directory": self.SOURCE_RAS_MODEL_DIRECTORY,
+            "model_name": self.MODEL_NAME,
             "source_network": {"file_name": self.SOURCE_NETWORK, "version": "2.1", "type": "nwm_hydrofabric"},
         }
         process = "conflate_model"

--- a/tests/conflation_tests.py
+++ b/tests/conflation_tests.py
@@ -45,7 +45,7 @@ RAS_GEOMETRY_GPKG = "Baxter.gpkg"
 def setup_data(request):
     nwm_pq_path = os.path.join(TEST_DIR, "nwm-data", NWM_REACHES_DATA)
     source_model_directory = os.path.join(TEST_DIR, "ras-data", RAS_DIR)
-    conflater = RasFimConflater(nwm_pq_path, source_model_directory)
+    conflater = RasFimConflater(nwm_pq_path, source_model_directory, RAS_DIR)
     request.cls.conflater = conflater
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def setup_data(request):
     request.cls.REACH_ID = REACH_ID
     request.cls.SOURCE_NETWORK = SOURCE_NETWORK
     request.cls.SOURCE_RAS_MODEL_DIRECTORY = SOURCE_RAS_MODEL_DIRECTORY
+    request.cls.MODEL_NAME = RAS_MODEL
     request.cls.SUBMODELS_BASE_DIRECTORY = SUBMODELS_BASE_DIRECTORY
     request.cls.SUBMODELS_DIRECTORY = SUBMODELS_DIRECTORY
     request.cls.GPKG_FILE = os.path.join(SUBMODELS_DIRECTORY, f"{REACH_ID}.gpkg")


### PR DESCRIPTION
This PR adds a required arg, `model_name` to the `conflate_model` endpoint. This enables the the user to specify the name of the model instead of inferring it from the model directory name which was not full proof. 

closes #186 
