### PR TITLE
Check RAS units are English

### DIFF
--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -109,45 +109,51 @@ class RasFimConflater:
         """The stac_api for the HEC-RAS Model."""
         if self.ras_metadata:
             if "stac_api" in self.ras_metadata.keys():
-                return self.ras_metadata["stac_api"]
+                return self.ras_metadata.get("stac_api")
 
     @property
     def stac_collection_id(self):
         """The stac_collection_id for the HEC-RAS Model."""
         if self.ras_metadata:
             if "stac_collection_id" in self.ras_metadata.keys():
-                return self.ras_metadata["stac_collection_id"]
+                return self.ras_metadata.get("stac_collection_id")
 
     @property
     def stac_item_id(self):
         """The stac_item_id for the HEC-RAS Model."""
         if self.ras_metadata:
             if "stac_item_id" in self.ras_metadata.keys():
-                return self.ras_metadata["stac_item_id"]
+                return self.ras_metadata.get("stac_item_id")
 
     @property
     def primary_geom_file(self):
         """The primary geometry file for the HEC-RAS Model."""
         if self.ras_metadata:
-            return self.ras_metadata["primary_geom_file"]
+            return self.ras_metadata.get("primary_geom_file")
 
     @property
     def primary_flow_file(self):
         """The primary flow file for the HEC-RAS Model."""
         if self.ras_metadata:
-            return self.ras_metadata["primary_flow_file"]
+            return self.ras_metadata.get("primary_flow_file")
 
     @property
     def primary_plan_file(self):
         """The primary plan file for the HEC-RAS Model."""
         if self.ras_metadata:
-            return self.ras_metadata["primary_plan_file"]
+            return self.ras_metadata.get("primary_plan_file")
 
     @property
     def ras_project_file(self):
         """The source HEC-RAS project file."""
         if self.ras_metadata:
-            return self.ras_metadata["ras_project_file"]
+            return self.ras_metadata.get("ras_project_file")
+
+    @property
+    def units(self):
+        """Units of the source HEC-RAS model."""
+        if self.ras_metadata is not None:
+            return self.ras_metadata.get("units")
 
     # @property
     # def xs_length_units(self):

--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -71,14 +71,6 @@ class RasModelStructure:
         return self.derive_path(".gpkg")
 
     @property
-    def units(self):
-        """Units specified in the metadata of the geopackage."""
-        conn = sqlite3.connect(self.ras_gpkg_file)
-        cur = conn.cursor()
-        res = cur.execute(f"SELECT value from metadata where key='units'")
-        return res.fetchone()[0]
-
-    @property
     def ras_xs(self):
         """RAS XS Geodataframe."""
         if self._ras_xs is None:
@@ -253,6 +245,13 @@ class RippleSourceDirectory:
             conflation_parameters = json.loads(f.read())
         return conflation_parameters["reaches"][nwm_id]
 
+    @property
+    def source_model_metadata(self):
+        """Metadata for the source model."""
+        with open(self.conflation_file, "r") as f:
+            conflation_parameters = json.loads(f.read())
+        return conflation_parameters["metadata"]
+
 
 class NwmReachModel(RasModelStructure):
     """National Water Model reach-based HEC-RAS Model files and directory structure."""
@@ -346,6 +345,11 @@ class NwmReachModel(RasModelStructure):
         with open(self.conflation_file, "r") as f:
             ripple1d_parameters = json.loads(f.read())
         return ripple1d_parameters
+
+    @property
+    def units(self):
+        """Units specified in the metadata of the geopackage."""
+        return self.ripple1d_parameters["source_model_metadata"]["source_ras_model"]["units"]
 
     def update_write_ripple1d_parameters(self, new_parameters: dict):
         """Write Ripple parameters."""

--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -71,6 +71,14 @@ class RasModelStructure:
         return self.derive_path(".gpkg")
 
     @property
+    def units(self):
+        """Units specified in the metadata of the geopackage."""
+        conn = sqlite3.connect(self.ras_gpkg_file)
+        cur = conn.cursor()
+        res = cur.execute(f"SELECT value from metadata where key='units'")
+        return res.fetchone()[0]
+
+    @property
     def ras_xs(self):
         """RAS XS Geodataframe."""
         if self._ras_xs is None:

--- a/ripple1d/errors.py
+++ b/ripple1d/errors.py
@@ -118,3 +118,5 @@ class SingleXSModel(Exception):
     """Raised when geopackage creation would yield a single cross-section model."""
 
 
+class UnitsError(Exception):
+    """Raised when units are not English."""

--- a/ripple1d/ops/ras_conflate.py
+++ b/ripple1d/ops/ras_conflate.py
@@ -222,6 +222,7 @@ def conflate_model(source_model_directory: str, source_network: dict):
         "stac_api": rfc.stac_api,
         "stac_collection_id": rfc.stac_collection_id,
         "stac_item_id": rfc.stac_item_id,
+        "units": rfc.units,
     }
     metadata["metadata"]["source_ras_model"]["source_ras_files"] = {
         "geometry": rfc.primary_geom_file,

--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from ripple1d.consts import DEFAULT_EPSG, MIN_FLOW
 from ripple1d.data_model import FlowChangeLocation, NwmReachModel
+from ripple1d.errors import UnitsError
 from ripple1d.ras import RasManager
 
 
@@ -68,6 +69,9 @@ def create_model_run_normal_depth(
 
     if not nwm_rm.file_exists(nwm_rm.ras_gpkg_file):
         raise FileNotFoundError(f"cannot find ras_gpkg_file file {nwm_rm.ras_gpkg_file}, please ensure file exists")
+
+    if nwm_rm.units != "English":
+        raise UnitsError(f"Can only process 'English' units at this time. '{nwm_rm.units}' was provided")
 
     if nwm_rm.ripple1d_parameters["eclipsed"] == True:
         logging.warning(f"skipping {nwm_rm.model_name}; no cross sections conflated.")


### PR DESCRIPTION
The PR checks that the source HEC-RAS model (and thus the derived submodel) have units of `English`. If it does not then an error is raised in the `create_model_run_normal_depth` endpoint. To do this several additional changes had to be made to the schema. 

- `units` is now passed from the source_model.gpkg to the conflation.json during `conflate_model`. 
- `source_model_metadata` is now passed from the conflation.json to the ripple1d.json  during `extract_submodel`. 
- `units` and `steady` (which is a boolean indicating if the source model was steady state) is now passed from the conflation.json to the submodel.gpkg  during `extract_submodel`. This required adding a new metadata table to the submodel.gpkg.
- `create_model_run_normal_depth` reads the ripple1d.json and raises an error if `units` is not `English`.

closes #123 