### PR TITLE
allow eclipsed reaches to pass validation check

### DIFF
--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -713,6 +713,8 @@ def validate_reach_conflation(reach_xs_data: dict, reach_id: str):
     The trim_reach method in subset_gpkg.py will return an empty geodataframe when u/s xs_id is lower than d/s xs_id.
     This likely indicates poor CRS inference.
     """
+    if reach_xs_data["eclipsed"]:
+        return  # eclipsed reaches always pass
     us = reach_xs_data["us_xs"]
     ds = reach_xs_data["ds_xs"]
     if (us["river"] == ds["river"]) & (us["reach"] == ds["reach"]) & (us["xs_id"] < ds["xs_id"]):


### PR DESCRIPTION
A check was added in 0.8.3 to ensure that u/s xs_id has a higher river station than d/s xs_id.  This error check did not account for eclipsed reaches that have neither u/s nor d/s cross-sections.  As a result, an error is raised and caught on eclipsed reaches, and those reaches are not added to the conflation.json.  This PR sets all eclipsed reaches to pass the conflation validation function added in 0.8.3.