### PR TITLE
Bugfix/ds nwm reach

### DIFF
--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -651,7 +651,7 @@ def map_reach_xs(rfc: RasFimConflater, reach: gpd.GeoSeries) -> dict:
     us_xs, ds_xs = retrieve_us_ds_xs(rfc, intersected_xs, reach)
 
     # detemine if us end of the nwm reach is between two cross sections. If so grab the upstream cross section (only if stream order=1)
-    if reach.stream_order == 1:
+    if reach.stream_order == 1 and reach.ID not in rfc.nwm_reaches["to_id"].values:
         us_xs = check_for_us_xs(us_xs, rfc.ras_xs)
 
     # Initialize us_xs data with min /max elevation, then build the dict with added info

--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -627,7 +627,7 @@ def check_for_us_xs(river_reach_rs, xs_gdf: gpd.GeoDataFrame) -> str:
         return river_reach_rs
 
 
-def map_reach_xs(rfc: RasFimConflater, reach: MultiLineString) -> dict:
+def map_reach_xs(rfc: RasFimConflater, reach: gpd.GeoSeries) -> dict:
     """
     Map the upstream and downstream cross sections for the nwm reach.
 

--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -217,7 +217,7 @@ class RasFimConflater:
             self._ras_centerlines = gpd.read_file(self.ras_gpkg, layer="River")
         if "XS" in layers:
             xs = gpd.read_file(self.ras_gpkg, layer="XS")
-            self._ras_xs = xs[xs.intersects(self._ras_centerlines.union_all())]
+            self._ras_xs = xs  # xs[xs.intersects(self._ras_centerlines.union_all())]
         if "Junction" in layers:
             self._ras_junctions = gpd.read_file(self.ras_gpkg, layer="Junction")
         if "Structure" in layers:

--- a/ripple1d/ops/ras_conflate.py
+++ b/ripple1d/ops/ras_conflate.py
@@ -158,13 +158,16 @@ def conflate_model(source_model_directory: str, model_name: str, source_network:
 def _conflate_model(source_model_directory: str, model_name: str, source_network: dict) -> dict:
     """Create dictionary mapping NWM reach to RAS u/s and d/s XS limits."""
     rfc = RasFimConflater(source_network["file_name"], source_model_directory, model_name)
-    local_nwm_reaches = list(set(chain.from_iterable([get_nwm_reaches(rr, rfc) for rr in rfc.ras_river_reach_names])))
+    local_nwm_reaches = list(
+        set(chain.from_iterable([get_nwm_reaches(rr, rfc) for rr in rfc.ras_river_reach_names]))
+    )  # time consuming but save
+    # local_nwm_reaches = list(rfc.local_nwm_reaches(buffer=1000)["ID"].values) #less time consuming but could potentially fail with multiple nwm reaches per single ras reach?
     conflation = {
         "reaches": ras_reaches_metadata(rfc, local_nwm_reaches),
         "metadata": generate_metadata(source_network, rfc),
     }
     conflation = find_eclipsed_reaches(rfc, conflation)
-    conflation = fix_junctions(rfc, conflation)
+    # conflation = fix_junctions(rfc, conflation)
     return conflation
 
 

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -133,8 +133,11 @@ class RippleGeopackageSubsetter:
     def source_xs(self) -> gpd.GeoDataFrame:
         """Extract cross sections from the source geopackage."""
         xs = gpd.read_file(self.src_gpkg_path, layer="XS")
-        source_xs = xs[xs.intersects(self.source_river.union_all())]
-        return source_xs
+        xs_subsets = []
+        for _, row in self.source_river.iterrows():
+            xs_subset = xs.loc[xs["river_reach"] == row["river_reach"]]
+            xs_subsets.append(xs_subset.loc[xs_subset.intersects(row.geometry)])
+        return pd.concat(xs_subsets).reset_index(drop=True)
 
     @property
     @lru_cache


### PR DESCRIPTION
This PR fixes several issues.

- Run times for conflate model have been improved by creating convex hulls of individual reaches and then unions those together and applying a buffer to select local NWM reaches.
- Several log statements were being raised as errors when they weren't actually errors, just logs.
- When Identifying the most downstream NWM reach for a given RAS reach, 5 candidate reaches are identified near the downstream RAS point (5 nearest NWM reaches). Each candidate NWM reach is checked for connectivity with the NWM reach that was identified for the upstream end of the RAS model. This is done by walking the NWM network. The first NWM reach that is connected is selected.  Previously only the nearest NWM reach was considered and would often fail.      
- The connectivity between each RAS reach whose cross sections intersected the NWM reach is now checked reach by reach. If multiple reach-groups of connected RAS reaches were identified the reach-group with the most coverage for the NWM is used. This should prevent tributary cross sections from intersecting with the NWM reach and incorrectly being used. It also improves the previous logic which was only checking the connectivity of the most upstream and downstream reaches.    
- First order streams are sometimes segmented (at bridges and such). This was breaking the logic when we identify a non-intersecting cross section that should be included with first order reaches; i.e., for intermediate first order streams we were incorrectly grabbing an additional cross section upstream of the NWM reach and thus causing overlap with the next reach upstream. This has been fixed so that there is no overlap. 

closes #321