### PR TITLE
Allow terrain metric failure

### DIFF
--- a/ripple1d/api/postman_collection.json
+++ b/ripple1d/api/postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "977032b0-6c0b-4437-9347-7061b817bdae",
+		"_postman_id": "aae308a3-7a55-4367-a5f4-8728c9165d68",
 		"name": "ripple1d",
 		"description": "Collection for processing existing HEC-RAS models for use in the production of Flood Inundation Maps (FIMs) and rating curves for use in near-real time flood forecasting on the NOAA National Water Model",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "29128857"
+		"_exporter_id": "38126273"
 	},
 	"item": [
 		{
@@ -162,7 +162,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"submodel_directory\": \"{{submodels_base_directory}}\\\\{{nwm_reach_id}}\",\r\n    \"resolution\": 3,\r\n    \"resolution_units\": \"Meters\",\r\n    \"terrain_agreement_resolution\": 3\r\n}",
+							"raw": "{\r\n    \"submodel_directory\": \"{{submodels_base_directory}}\\\\{{nwm_reach_id}}\",\r\n    \"resolution\": 3,\r\n    \"resolution_units\": \"Meters\",\r\n    \"terrain_agreement_resolution\": 3,\r\n    \"terrain_agreement_ignore_error\": false\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/ripple1d/ops/ras_terrain.py
+++ b/ripple1d/ops/ras_terrain.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import traceback
 from math import ceil, comb, pi
 from pathlib import Path
 
@@ -66,7 +67,7 @@ def create_ras_terrain(
     terrain_agreement_el_repeats: int = 5,
     terrain_agreement_el_ramp_rate: float = 2.0,
     terrain_agreement_el_init: float = 0.5,
-    ignore_error: bool = True,
+    terrain_agreement_ignore_error: bool = True,
 ):
     """Create a RAS terrain file.
 
@@ -106,6 +107,8 @@ def create_ras_terrain(
         21.5, etc.
     terrain_agreement_el_init : float, optional
         initial value for terrain agreement elevation increments, by default 0.5
+    terrain_agreement_ignore_error : bool, optional
+        whether to raise or log+ignore any errors encountered in the compute_terrain_agreement_metrics function.
     task_id : str, optional
         Task ID to use for logging, by default ""
 
@@ -209,8 +212,11 @@ def create_ras_terrain(
         )
         result["terrain_agreement"] = agreement_path
     except Exception as e:
-        if not ignore_error:
+        if not terrain_agreement_ignore_error:
             raise e
+        logging.error(f"| Error: {e}")
+        logging.error(f"| Traceback: {traceback.format_exc()}")
+
         result["terrain_agreement"] = None
     return result
 

--- a/ripple1d/ops/ras_terrain.py
+++ b/ripple1d/ops/ras_terrain.py
@@ -66,6 +66,7 @@ def create_ras_terrain(
     terrain_agreement_el_repeats: int = 5,
     terrain_agreement_el_ramp_rate: float = 2.0,
     terrain_agreement_el_init: float = 0.5,
+    ignore_error: bool = True,
 ):
     """Create a RAS terrain file.
 
@@ -195,17 +196,22 @@ def create_ras_terrain(
     logging.info(f"create_ras_terrain complete")
 
     # Calculate terrain agreement metrics
-    agreement_path = compute_terrain_agreement_metrics(
-        submodel_directory,
-        terrain_path,
-        terrain_agreement_resolution,
-        resolution_units,
-        terrain_agreement_format,
-        terrain_agreement_el_repeats,
-        terrain_agreement_el_ramp_rate,
-        terrain_agreement_el_init,
-    )
-    result["terrain_agreement"] = agreement_path
+    try:
+        agreement_path = compute_terrain_agreement_metrics(
+            submodel_directory,
+            terrain_path,
+            terrain_agreement_resolution,
+            resolution_units,
+            terrain_agreement_format,
+            terrain_agreement_el_repeats,
+            terrain_agreement_el_ramp_rate,
+            terrain_agreement_el_init,
+        )
+        result["terrain_agreement"] = agreement_path
+    except Exception as e:
+        if not ignore_error:
+            raise e
+        result["terrain_agreement"] = None
     return result
 
 


### PR DESCRIPTION
This PR closes #327.  A new argument was added to the `create_ras_terrain` endpoint to allow errors in the terrain agreement calculation to be ignored.