### PR TITLE
Bugfix/terrain metric performance

### DIFF
--- a/ripple1d/data_model.py
+++ b/ripple1d/data_model.py
@@ -654,7 +654,11 @@ class XS:
     def centerline_intersection_point(self):
         """A point located where the cross section and reach centerline intersect."""
         if self.cross_section_intersects_reach:
-            return self.reach_geom.intersection(self.geom)
+            intersection = self.reach_geom.intersection(self.geom)
+            if intersection.geom_type == "Point":
+                return intersection
+            if intersection.geom_type == "MultiPoint":
+                return intersection.geoms[0]
 
     @property
     def left_reach_length_ratio(self):

--- a/ripple1d/ops/ras_terrain.py
+++ b/ripple1d/ops/ras_terrain.py
@@ -521,6 +521,9 @@ def get_wses(
         start_el += terrain_agreement_el_init
     end_el = min((xs[0, 1], xs[-1, 1]))
     end_el = ceil(end_el / terrain_agreement_el_init) * terrain_agreement_el_init  # Round to nearest init_inc
+    end_el = max(
+        end_el, start_el
+    )  # If section was poorly created with endpoints not on high ground, get at least one metric.
 
     increments = np.arange(0, 10, 1)
     increments = (terrain_agreement_el_ramp_rate**increments) * terrain_agreement_el_init

--- a/ripple1d/ras.py
+++ b/ripple1d/ras.py
@@ -791,7 +791,8 @@ class RasGeomText(RasTextFile):
         self.units = units
         self.hdf_file = self._ras_text_file_path + ".hdf"
 
-        self.fix_htab_errors()
+        if len(ras_text_file_path) > 0:
+            self.fix_htab_errors()
 
     def __repr__(self):
         """Representation of the RasGeomText class."""
@@ -813,6 +814,7 @@ class RasGeomText(RasTextFile):
         inst._title = title
 
         inst.contents = inst._content_from_gpkg
+        inst.fix_htab_errors()
         return inst
 
     @property
@@ -950,6 +952,7 @@ class RasGeomText(RasTextFile):
         return junctions
 
     @property
+    @lru_cache
     @check_crs
     def cross_sections(self) -> dict:
         """A dictionary of the cross sections contained in the HEC-RAS geometry file."""

--- a/ripple1d/utils/ripple_utils.py
+++ b/ripple1d/utils/ripple_utils.py
@@ -354,7 +354,10 @@ def data_pairs_from_text_block(lines: list[str], width: int) -> list[tuple[float
         for i in range(0, len(line), width):
             x = line[i : int(i + width / 2)]
             y = line[int(i + width / 2) : int(i + width)]
-            pairs.append((float(x), float(y)))
+            try:
+                pairs.append((float(x), float(y)))
+            except ValueError:  # If a user has left a coordinate blank, skip point
+                continue
 
     return pairs
 


### PR DESCRIPTION
This PR closes #328 and #344.  

1. #344 was resolved by adding an lru_cache to the RasGeomText cross_sections property.  the htab error fixing step needed to be moved because it was found that it was not being applied to RasGeomText classes instantiated with the from_gpkg method.  This would throw off the caching by making cross_sections return an empty list for class instances generated with the from_gpkg  method.
2. #328 included several sub errors
    * Areas where a ras river line intersects a cross-section at multiple locations will default to treating the first intersection as the only intersection
    * A minimum of one cross-section elevation-based terrain agreement metric is now generated even when section endpoints are lower than the thalweg
    * cross-sections vertices where a user did not enter a value for either station or elevation will be ignored.