### PR TITLE
Bugfix/concave hull

### DIFF
--- a/ripple1d/consts.py
+++ b/ripple1d/consts.py
@@ -4,9 +4,10 @@ from collections import OrderedDict
 
 SUPPRESS_LOGS = ["boto3", "botocore", "geopandas", "fiona", "rasterio", "pyogrio", "shapely"]
 
-MAP_DEM_UNCLIPPED_SRC_URL = (
-    "https://rockyweb.usgs.gov/vdelivery/Datasets/Staged/Elevation/13/TIFF/USGS_Seamless_DEM_13.vrt"
-)
+# MAP_DEM_UNCLIPPED_SRC_URL = (
+#     "https://rockyweb.usgs.gov/vdelivery/Datasets/Staged/Elevation/13/TIFF/USGS_Seamless_DEM_13.vrt"
+# )
+MAP_DEM_UNCLIPPED_SRC_URL = "https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/USGS_Seamless_DEM_13.vrt"
 
 MAP_DEM_BUFFER_DIST_FT = 1000.0
 MAP_DEM_DIRNAME = "MapTerrain"

--- a/ripple1d/ops/subset_gpkg.py
+++ b/ripple1d/ops/subset_gpkg.py
@@ -454,7 +454,9 @@ class RippleGeopackageSubsetter:
             if gdf.shape[0] > 0:
                 gdf.to_file(self.ripple_gpkg_file, layer=layer)
                 if layer == "XS":
-                    self.ripple_xs_concave_hull.to_file(self.ripple_gpkg_file, driver="GPKG", layer="XS_concave_hull")
+                    xs = fix_reversed_xs(gdf, self.subset_gdfs["River"])
+                    xs.sort_values(by="river_station", inplace=True, ascending=False)
+                    xs_concave_hull(xs).to_file(self.ripple_gpkg_file, driver="GPKG", layer="XS_concave_hull")
 
     def correct_ras_data(self, row):
         """Make ras_data names consistent with river_station."""


### PR DESCRIPTION
This PR resolves a bug that was effecting the cross section concave hull for the subset models. In some instances the entire concave hull of the source model was being used for the subset model. This has been remedied.  

closes #336