### PR TITLE
bugfix 1.2*100yr flow

### DIFF
--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -414,13 +414,13 @@ class RasFimConflater:
         metadata = {}
         flow_data = self.nwm_reaches[self.nwm_reaches["ID"] == reach_id].iloc[0]
         if isinstance(flow_data["high_flow_threshold"], float):
-            metadata["low_flow"] = int(round(flow_data["high_flow_threshold"], 2) * HIGH_FLOW_FACTOR)
+            metadata["low_flow"] = int(round(flow_data["high_flow_threshold"], 2))
         else:
             metadata["low_flow"] = -9999
             logging.warning(f"No low flow data for {reach_id}")
 
         try:
-            high_flow = float(flow_data["f100year"])
+            high_flow = float(flow_data["f100year"]) * HIGH_FLOW_FACTOR
             metadata["high_flow"] = int(round(high_flow, 2))
         except:
             logging.warning(f"No high flow data for {reach_id}")


### PR DESCRIPTION
This PR fixes a bug with the NWM flows. Previously we were multiplying the `high_flow_threshold` by 1.2 to represent the low flow applied in ripple. This was incorrect. The low flow for ripple should be simply the `high_flow_threshold`. The high flow for ripple should be the `100yr` from the NWM multiplied by 1.2. These resulting NWM low and high flows are then compared to the smallest and largest flows in the source model to determine the widest range of flows that would be applied to ripple. 

closes #359
closes #358